### PR TITLE
Fix build, add Perl CI test, reflow docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y libdevel-nytprof-perl
       - run: python -m pip install -e .[dev] pytest
       - run: pytest -q
+      - name: profile & render
+        run: |
+          python -m pynytprof.tracer tests/example_script.py
+          nytprofhtml -f nytprof.out -o report
+          test -f report/index.html
+

--- a/README.md
+++ b/README.md
@@ -1,24 +1,12 @@
 # Pynytprof
 
-Goal: line-accurate, low-overhead Python profiler that emits **exactly the same
-binary stream** as Devel::NYTProf.  We rely on Perl’s `nytprofhtml` to render
-HTML until our own UI exists.
-
-Quick start
-```bash
+Line-accurate Python profiler that emits Devel::NYTProf files. Use Perl's `nytprofhtml`
+for rendering until a dedicated UI exists.
 
 ```bash
-# dev install
 python -m pip install -e .
-
-# record a profile
-pynytprof tests/example_script.py
-
-# generate HTML with Perl's tooling
+pynytprof your_script.py
 nytprofhtml -f nytprof.out
-xdg-open nytprof/index.html
 ```
 
-Current status: MVP = emit H A F S E chunks only. Call graphs come later.
-
----
+Current status: MVP writes only H A F S E chunks.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,19 +1,18 @@
 ## Data path
 
-CPython frame-eval → `tracer.py` (gathers line events) → `_writer.c`
-(pack structs, spill to `nytprof.out`) → Perl `nytprofhtml` → HTML.
+CPython frame-eval -> `tracer.py` gathers line events -> `_writer.c` packs structs and
+spills to `nytprof.out` -> Perl `nytprofhtml` -> HTML.
 
-``tracer.py`` stays pure-Python so users can prototype quickly; the C writer
-handles the hot loop so overhead stays <5×.
+`tracer.py` stays pure Python so users can prototype quickly, while the C writer handles the
+hot loop so overhead stays under 5×.
 
 ### Major modules
 
-| Module        | Responsibility                            |
-|---------------|-------------------------------------------|
-| `tracer.py`   | subscribe to frame events, queue records  |
-| `_writer.c`   | ring-buffer + `write()` burst flush       |
-| `reader.py`   | (dev-only) decode records for tests       |
+| Module      | Responsibility                           |
+|-------------|------------------------------------------|
+| `tracer.py` | subscribe to frame events, queue records |
+| `_writer.c` | ring buffer + `write()` burst flush      |
+| `reader.py` | (dev-only) decode records for tests      |
 
-Call depth is measured with `frame->f_depth`.  Wall-clock ticks use
-`clock_gettime(CLOCK_MONOTONIC_RAW)` on POSIX and `QueryPerformanceCounter`
-on Windows.
+Call depth comes from `frame->f_depth`. Wall-clock ticks use `clock_gettime(CLOCK_MONOTONIC_RAW)`
+on POSIX and `QueryPerformanceCounter` on Windows.

--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -1,5 +1,5 @@
-> **Scope**: minimal stream that Perl’s `Devel::NYTProf::Reader` accepts.
-> We copy constants from NYTProf v5.0 :contentReference[oaicite:0]{index=0}.
+> **Scope**: minimal stream that Perl's `Devel::NYTProf::Reader` accepts. We copy constants from
+> NYTProf v5.0.
 
 ### Top-level layout
 
@@ -12,32 +12,30 @@ chunk[] (see below)
 
 ### Chunk wire format
 
-| Field      | Size | Notes                 |
-|------------|------|-----------------------|
-| token      | u8   | ASCII letter          |
-| length     | u32  | little-endian payload |
-| payload    | var  | chunk-specific        |
+| Field   | Size | Notes                 |
+|---------|------|-----------------------|
+| token   | u8   | ASCII letter          |
+| length  | u32  | little-endian payload |
+| payload | var  | chunk-specific        |
 
 ### Mandatory chunks for MVP
 
-| Token | Payload struct | What to fill                                     |
-|-------|----------------|--------------------------------------------------|
-| `H`   | `{u32 major,u32 minor}`                                     | copy header versions |
-| `A`   | key=value NUL-joined string table                           | **required keys**: `ticks_per_sec`, `start_time` |
-| `F`   | repeat `{u32 fid, u32 flags, u32 size, u32 mtime, zstr path}` | at least your script = fid 0, set `flags |= 0x10` (HAS_SRC) |
-| `S`   | repeat `{u32 fid, u32 line, u32 calls, u64 inc_ticks, u64 exc_ticks}` | one record per executed line |
-| `E`   | empty                                                     | terminator |
+| Token | Payload struct                                               | What to fill                                                       |
+|-------|--------------------------------------------------------------|-------------------------------------------------------------------|
+| `H`   | `{u32 major,u32 minor}`                                      | copy header versions                                              |
+| `A`   | key=value NUL-joined string table                             | required keys: `ticks_per_sec`, `start_time`                      |
+| `F`   | repeat `{u32 fid,u32 flags,u32 size,u32 mtime, zstr path}`   | at least your script = fid 0, set `flags |= 0x10` (HAS_SRC)       |
+| `S`   | repeat `{u32 fid,u32 line, u32 calls, u64 inc_ticks, u64 exc_ticks}` | one record per executed line                                     |
+| `E`   | empty                                                        | terminator                                                        |
 
-Skip call-graph chunks (`C`,`D`) for now—`nytprofhtml` still renders per-line
-heat maps just fine. If the reader bombs, look for **“File format error:
-token X”**.
+Skip call-graph chunks (`C`,`D`) for now. `nytprofhtml` still renders per-line heat maps. If the
+reader complains, look for "File format error: token X".
 
 ### Tick units
 
-`ticks_per_sec` must match the constant used in the writer.  We default to
-10 000 000 (100 ns)—same as NYTProf’s `TICKS_PER_SEC` macro :contentReference[oaicite:1]{index=1}.
+`ticks_per_sec` must match the constant used in the writer. We default to 10,000,000 (100 ns)—the
+same value as NYTProf's `TICKS_PER_SEC` macro.
 
 ### Endianness
 
 Always little-endian; NYTProf refuses big-endian files.
-

--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -1,11 +1,11 @@
 ### Bootstrapping
-- [ ] tracer.py: hook `sys.settrace` as a fallback for Py<3.12.
-- [ ] _writer.c: proof-of-concept that writes hard-coded `H`..`E` for a
-      3-line script, verified by `nytprofhtml`.
+- [ ] tracer.py: hook `sys.settrace` as a fallback for Python <3.12.
+- [ ] _writer.c: proof-of-concept that writes hard-coded `H`..`E` for a three-line script,
+      verified by `nytprofhtml`.
 - [ ] tests/test_smoke.py: assert `nytprof.out` exists & >0 bytes.
 
 ### Performance
-- [ ] Replace GIL-held Python queue with lock-free ring buffer.
+- [ ] Replace GIL-held Python queue with a lock-free ring buffer.
 - [ ] Support `NYTPROF_FILTER="package/*"` globs.
 
 ### Stretch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,3 @@ line-length = 99
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.setuptools.extension."pynytprof._cwrite"]
-sources = ["src/pynytprof/_writer.c"]
-
-[tool.setuptools.extension."pynytprof._tracer"]
-sources = ["src/pynytprof/_tracer.c"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, Extension
+setup(
+    name='pynytprof',
+    version='0.0.0',
+    packages=['pynytprof'],
+    package_dir={'': 'src'},
+    ext_modules=[
+        Extension('pynytprof._writer', ['src/pynytprof/_writer.c']),
+        Extension('pynytprof._tracer', ['src/pynytprof/_tracer.c']),
+    ],
+)


### PR DESCRIPTION
## Summary
- clean up `pyproject.toml`
- add classic `setup.py`
- update CI to install NYTProf and verify HTML rendering
- reflow README and docs

## Testing
- `pytest -q`
- `sudo apt-get update` *(fails: repository not signed)*
- `sudo apt-get install -y libdevel-nytprof-perl` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_685ebe3325788331bc01578d73492f4a