### PR TITLE
Add Speedscope JSON converter and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ an error status if the file is corrupted.
 ```bash
 pynytprof verify nytprof.out
 ```
+
+## Flamegraph output
+Use `convert` to generate Speedscope JSON and view results in a browser.
+
+```bash
+pynytprof convert --speedscope nytprof.out
+```

--- a/src/pynytprof/convert.py
+++ b/src/pynytprof/convert.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .reader import read
+
+__all__ = ["to_speedscope"]
+
+
+def to_speedscope(in_path: str, out_path: str) -> None:
+    data = read(in_path)
+    script = Path(data.get("files", {}).get(0, {}).get("path", "script")).name
+    events = []
+    current = 0
+    for fid, line, _calls, inc, _exc in data.get("records", []):
+        start = current
+        dur_us = inc // 10
+        events.append({"type": "O", "at": start, "name": f"<line {line}>"})
+        events.append({"type": "C", "at": start + dur_us})
+        current += dur_us
+    result = {
+        "schema": "https://www.speedscope.app/file-format-schema.json",
+        "version": "0.3.0",
+        "profiles": [
+            {
+                "type": "evented",
+                "name": script,
+                "unit": "microseconds",
+                "events": events,
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(result))

--- a/src/pynytprof/main.py
+++ b/src/pynytprof/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import tracer, reader
+from . import convert
+
+
+def _verify(path: str) -> int:
+    try:
+        data = reader.read(path)
+    except ValueError as e:
+        print(f"{path} \u2717  {e}")
+        return 1
+    except OSError as e:
+        print(f"{path} \u2717  {e}")
+        return 2
+    ticks = sum(r[4] for r in data["records"])
+    tick_str = f"{ticks:,}".replace(",", " ")
+    print(f"{path} \u2713  {len(data['records'])} lines, {tick_str} total ticks")
+    return 0
+
+
+def _convert_speedscope(src: str, dest: str | None) -> None:
+    out = dest or str(Path(src).with_suffix(".speedscope.json"))
+    convert.to_speedscope(src, out)
+
+
+def cli(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] not in {"profile", "verify", "convert"}:
+        argv.insert(0, "profile")
+    p = argparse.ArgumentParser(prog="pynytprof")
+    sp = p.add_subparsers(dest="cmd", required=True)
+    pr = sp.add_parser("profile")
+    pr.add_argument("script")
+    pr.add_argument("args", nargs=argparse.REMAINDER)
+    vr = sp.add_parser("verify")
+    vr.add_argument("path")
+    cv = sp.add_parser("convert")
+    cv.add_argument("--speedscope", action="store_true")
+    cv.add_argument("src")
+    cv.add_argument("dest", nargs="?")
+    args = p.parse_args(argv)
+    if args.cmd == "verify":
+        return _verify(args.path)
+    if args.cmd == "convert":
+        if args.speedscope:
+            _convert_speedscope(args.src, args.dest)
+            return 0
+        p.error("convert: no format specified")
+    sys.argv = [args.script] + args.args
+    tracer.profile_script(args.script)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,34 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_convert(tmp_path):
+    script = Path(__file__).with_name("example_script.py")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        str(script),
+    ], cwd=tmp_path, env=env)
+    out_json = tmp_path / "out.json"
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.main",
+        "convert",
+        "--speedscope",
+        "nytprof.out",
+        str(out_json),
+    ], cwd=tmp_path, env=env)
+    data = json.loads(out_json.read_text())
+    assert data["schema"]
+    assert data["version"] == "0.3.0"
+    assert data["profiles"]
+    events = data["profiles"][0]["events"]
+    assert any(e["type"] == "O" for e in events)
+    assert any(e["type"] == "C" for e in events)


### PR DESCRIPTION
## Summary
- add `convert.py` with a helper to produce Speedscope JSON
- implement new `convert` command in `pynytprof.main`
- test conversion workflow
- document Speedscope/Flamegraph usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eca32b2688331ac321ca4bb63124b