### PR TITLE
Add multi-file F table and C/D chunks for call graph

### DIFF
--- a/src/pynytprof/_tracer.c
+++ b/src/pynytprof/_tracer.c
@@ -15,6 +15,7 @@
 
 /* ring slot record */
 typedef struct {
+    PyObject *path;
     uint32_t line;
     uint32_t calls;
     uint64_t inc_ns;
@@ -28,12 +29,25 @@ static Rec *ring = NULL;
 static _Atomic int ring_lock = 0;
 static uint64_t last_ns = 0;
 static char *script_path = NULL;
-static PyObject *write_func = NULL;
-static PyObject *script_obj = NULL;
 static uint64_t start_ns = 0;
 static _PyFrameEvalFunction prev_eval = NULL;
 static char **filters = NULL;
 static size_t filter_count = 0;
+static PyObject *code_to_id = NULL;
+static PyObject *defs_list = NULL;
+static PyObject *calls_list = NULL;
+
+#define MAX_STACK 1024
+typedef struct {
+    PyObject *path;
+    uint32_t line;
+    uint32_t sub_id;
+    uint64_t start_ns;
+    uint64_t child_ns;
+} StackItem;
+static StackItem stack[MAX_STACK];
+static int stack_top = 0;
+static uint32_t next_sub_id = 1;
 
 static void free_filters(void) {
     if (!filters)
@@ -95,13 +109,20 @@ static inline void unlock(void) {
 }
 
 /* add line timing to ring */
-static void record_line(int line, uint64_t dt) {
-    size_t idx = (size_t)line & (RING_SIZE - 1);
+static void record_line(PyObject *path, int line, uint64_t dt) {
+    size_t idx = ((size_t)line ^ (size_t)path) & (RING_SIZE - 1);
     for (size_t i = 0; i < RING_SIZE; i++) {
         Rec *r = &ring[idx];
-        if (r->line == 0 || r->line == (uint32_t)line) {
-            if (r->line == 0)
-                r->line = (uint32_t)line;
+        if (r->path == NULL) {
+            r->path = path;
+            Py_INCREF(path);
+            r->line = (uint32_t)line;
+            r->calls = 1;
+            r->inc_ns += dt;
+            r->exc_ns += dt;
+            return;
+        }
+        if (r->line == (uint32_t)line && r->path == path) {
             r->calls += 1;
             r->inc_ns += dt;
             r->exc_ns += dt;
@@ -109,6 +130,36 @@ static void record_line(int line, uint64_t dt) {
         }
         idx = (idx + 1) & (RING_SIZE - 1);
     }
+}
+
+/* map code objects to sub IDs and record definitions */
+static uint32_t get_sub_id(PyCodeObject *code) {
+    PyObject *id_obj = PyDict_GetItem(code_to_id, (PyObject *)code);
+    if (id_obj)
+        return (uint32_t)PyLong_AsUnsignedLong(id_obj);
+
+    uint32_t sub_id = next_sub_id++;
+    id_obj = PyLong_FromUnsignedLong(sub_id);
+    PyDict_SetItem(code_to_id, (PyObject *)code, id_obj);
+    Py_DECREF(id_obj);
+
+    PyObject *name = code->co_name;
+    if (PyUnicode_Check(name) && PyUnicode_CompareWithASCIIString(name, "<module>") == 0)
+        name = PyUnicode_FromString("(module)");
+    else
+        Py_INCREF(name);
+
+    PyObject *def = PyTuple_New(5);
+    PyTuple_SET_ITEM(def, 0, PyLong_FromUnsignedLong(sub_id));
+    Py_INCREF(code->co_filename);
+    PyTuple_SET_ITEM(def, 1, code->co_filename);
+    PyTuple_SET_ITEM(def, 2, PyLong_FromLong(code->co_firstlineno));
+    PyTuple_SET_ITEM(def, 3, PyLong_FromLong(code->co_firstlineno));
+    PyTuple_SET_ITEM(def, 4, name);
+    PyList_Append(defs_list, def);
+    Py_DECREF(def);
+
+    return sub_id;
 }
 
 /* trace callback */
@@ -157,7 +208,7 @@ static int tracefunc(PyObject *obj, PyFrameObject *f, int what, PyObject *arg) {
     uint64_t dt = last_ns ? now - last_ns : 0;
     last_ns = now;
     lock();
-    record_line(line, dt);
+    record_line(f->f_code->co_filename, line, dt);
     unlock();
     return 0;
 }
@@ -170,7 +221,52 @@ static PyObject *tracer_eval(PyThreadState *ts, PyFrameObject *f, int throwflag)
     ts->c_tracefunc = tracefunc;
     ts->c_traceobj = NULL;
     ts->use_tracing = 1;
+
+    PyObject *call_path = NULL;
+    uint32_t call_line = 0;
+    if (f->f_back) {
+        call_path = f->f_back->f_code->co_filename;
+        Py_INCREF(call_path);
+        call_line = (uint32_t)PyFrame_GetLineNumber(f->f_back);
+    }
+
+    uint32_t sub_id = get_sub_id((PyCodeObject *)f->f_code);
+    uint64_t start = PyTime_GetPerfCounter();
+    if (stack_top < MAX_STACK) {
+        stack[stack_top].path = call_path;
+        stack[stack_top].line = call_line;
+        stack[stack_top].sub_id = sub_id;
+        stack[stack_top].start_ns = start;
+        stack[stack_top].child_ns = 0;
+        stack_top++;
+    } else {
+        Py_XDECREF(call_path);
+    }
+
     PyObject *res = prev_eval(ts, f, throwflag);
+    uint64_t end = PyTime_GetPerfCounter();
+
+    if (stack_top > 0) {
+        StackItem item = stack[--stack_top];
+        uint64_t dur = end - item.start_ns;
+        uint64_t exc = dur - item.child_ns;
+        PyObject *t = PyTuple_New(5);
+        if (item.path)
+            PyTuple_SET_ITEM(t, 0, item.path);
+        else {
+            Py_INCREF(Py_None);
+            PyTuple_SET_ITEM(t, 0, Py_None);
+        }
+        PyTuple_SET_ITEM(t, 1, PyLong_FromUnsignedLong(item.line));
+        PyTuple_SET_ITEM(t, 2, PyLong_FromUnsignedLong(item.sub_id));
+        PyTuple_SET_ITEM(t, 3, PyLong_FromUnsignedLongLong(dur));
+        PyTuple_SET_ITEM(t, 4, PyLong_FromUnsignedLongLong(exc));
+        PyList_Append(calls_list, t);
+        Py_DECREF(t);
+        if (stack_top > 0)
+            stack[stack_top - 1].child_ns += dur;
+    }
+
     ts->c_tracefunc = oldfunc;
     ts->c_traceobj = oldobj;
     ts->use_tracing = olduse;
@@ -178,65 +274,43 @@ static PyObject *tracer_eval(PyThreadState *ts, PyFrameObject *f, int throwflag)
 }
 
 /* shutdown handler */
-static void tracer_shutdown(void) {
-    if (!ring)
-        return;
-    PyGILState_STATE g = PyGILState_Ensure();
-
-    struct stat st;
-    uint32_t size = 0, mtime = 0;
-    if (script_path && stat(script_path, &st) == 0) {
-        size = (uint32_t)st.st_size;
-        mtime = (uint32_t)st.st_mtime;
-    }
-
+/* dump collected data */
+static PyObject *ctrace_dump(PyObject *self, PyObject *args) {
     PyObject *records = PyList_New(0);
     if (!records)
-        goto done;
+        return NULL;
     for (size_t i = 0; i < RING_SIZE; i++) {
         Rec *r = &ring[i];
-        if (!r->line || !r->calls)
+        if (!r->path || !r->calls)
             continue;
-        PyObject *t = PyTuple_New(4);
-        if (!t)
-            goto done;
-        PyTuple_SET_ITEM(t, 0, PyLong_FromUnsignedLong(r->line));
-        PyTuple_SET_ITEM(t, 1, PyLong_FromUnsignedLong(r->calls));
-        PyTuple_SET_ITEM(t, 2, PyLong_FromUnsignedLongLong(r->inc_ns));
-        PyTuple_SET_ITEM(t, 3, PyLong_FromUnsignedLongLong(r->exc_ns));
+        PyObject *t = PyTuple_New(5);
+        PyTuple_SET_ITEM(t, 0, r->path); /* steal */
+        PyTuple_SET_ITEM(t, 1, PyLong_FromUnsignedLong(r->line));
+        PyTuple_SET_ITEM(t, 2, PyLong_FromUnsignedLong(r->calls));
+        PyTuple_SET_ITEM(t, 3, PyLong_FromUnsignedLongLong(r->inc_ns));
+        PyTuple_SET_ITEM(t, 4, PyLong_FromUnsignedLongLong(r->exc_ns));
         PyList_Append(records, t);
         Py_DECREF(t);
+        r->path = NULL;
     }
-
-    if (write_func) {
-        PyObject *path = PyUnicode_FromString("nytprof.out");
-        PyObject *size_obj = PyLong_FromUnsignedLong(size);
-        PyObject *mtime_obj = PyLong_FromUnsignedLong(mtime);
-        PyObject *start_obj = PyLong_FromUnsignedLongLong(start_ns);
-        PyObject *ticks_obj = PyLong_FromUnsignedLongLong(TICKS_PER_SEC);
-        PyObject *args = PyTuple_Pack(7, path, script_obj, size_obj, mtime_obj,
-                                     start_obj, ticks_obj, records);
-        if (args) {
-            PyObject *res = PyObject_CallObject(write_func, args);
-            Py_XDECREF(res);
-            Py_DECREF(args);
-        }
-        Py_DECREF(path);
-        Py_DECREF(size_obj);
-        Py_DECREF(mtime_obj);
-        Py_DECREF(start_obj);
-        Py_DECREF(ticks_obj);
-    }
+    PyObject *defs = defs_list ? defs_list : PyList_New(0);
+    PyObject *calls = calls_list ? calls_list : PyList_New(0);
+    Py_INCREF(defs);
+    Py_INCREF(calls);
+    PyObject *ret = PyTuple_Pack(3, defs, calls, records);
+    Py_DECREF(defs);
+    Py_DECREF(calls);
     Py_DECREF(records);
 
-done:
     PyMem_RawFree(ring);
     ring = NULL;
-    Py_XDECREF(write_func);
-    Py_XDECREF(script_obj);
+    Py_CLEAR(defs_list);
+    Py_CLEAR(calls_list);
+    Py_CLEAR(code_to_id);
     free(script_path);
+    script_path = NULL;
     free_filters();
-    PyGILState_Release(g);
+    return ret;
 }
 
 /* enable tracing */
@@ -259,25 +333,20 @@ static PyObject *ctrace_enable(PyObject *self, PyObject *args) {
     script_path = strdup(path);
     if (!script_path)
         return PyErr_NoMemory();
-    script_obj = PyUnicode_FromString(path);
-    if (!script_obj)
-        return NULL;
-    PyObject *mod = PyImport_ImportModule("pynytprof._cwrite");
-    if (!mod)
-        return NULL;
-    write_func = PyObject_GetAttrString(mod, "write");
-    Py_DECREF(mod);
-    if (!write_func)
-        return NULL;
+    code_to_id = PyDict_New();
+    defs_list = PyList_New(0);
+    calls_list = PyList_New(0);
+    if (!code_to_id || !defs_list || !calls_list)
+        return PyErr_NoMemory();
     PyInterpreterState *interp = PyInterpreterState_Get();
     prev_eval = PyInterpreterState_GetEvalFrameFunc(interp);
     PyInterpreterState_SetEvalFrameFunc(interp, tracer_eval);
-    Py_AtExit(tracer_shutdown);
     Py_RETURN_NONE;
 }
 
 static PyMethodDef Methods[] = {
     {"enable", ctrace_enable, METH_VARARGS, "enable c tracer"},
+    {"dump", ctrace_dump, METH_NOARGS, "dump collected data"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/tests/cg_example.py
+++ b/tests/cg_example.py
@@ -1,0 +1,9 @@
+
+def foo():
+    bar()
+
+def bar():
+    return 42
+
+if __name__ == "__main__":
+    foo()

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import shutil
+import pytest
+
+
+def test_callgraph(tmp_path):
+    script = Path(__file__).with_name("cg_example.py")
+    if not shutil.which("nytprofhtml"):
+        pytest.skip("nytprofhtml missing")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        str(script),
+    ], cwd=tmp_path, env=env)
+    subprocess.check_call(["nytprofhtml", "-f", "nytprof.out"], cwd=tmp_path)
+    html = (tmp_path / "nytprof" / "index.html").read_text()
+    assert "cg_example.py->foo" in html


### PR DESCRIPTION
## Summary
- extend native tracer to capture function definitions and calls
- stream new F, D and C records in writer
- wire Python tracer to assign file IDs and call writer
- add call-graph example and regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecbed2b40833181887ff991d52b9b