### PR TITLE
Fix NYTPROF header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           python-version: '3.12'
       - run: sudo apt-get update
-      - run: sudo apt-get install -y libdevel-nytprof-perl
+      - run: sudo apt-get install --no-install-recommends -y libdevel-nytprof-perl
       - run: python -m pip install -e .[dev] pytest
       - run: pytest -q
       - name: profile & render

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -48,10 +48,12 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
     if (!fp)
         return PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
 
-    unsigned char header[16];
-    memcpy(header, "NYTPROF\0", 8);
-    put_u32le(header + 8, 5);
-    put_u32le(header + 12, 0);
+    static const char MAGIC[8] = "NYTPROF\0";
+    fwrite(MAGIC, 1, 8, fp);
+
+    unsigned char header[8];
+    put_u32le(header, 5);
+    put_u32le(header + 4, 0);
 
     unsigned char hchunk[13];
     hchunk[0] = 'H';
@@ -220,7 +222,7 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
     echunk[0] = 'E';
     put_u32le(echunk + 1, 0);
 
-    fwrite(header, 16, 1, fp);
+    fwrite(header, 8, 1, fp);
     fwrite(hchunk, 13, 1, fp);
     fwrite(achunk, 5 + a_len, 1, fp);
     fwrite(fchunk, 5 + f_len, 1, fp);

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -6,7 +6,7 @@ __all__ = ["read"]
 
 def read(path: str) -> dict:
     data = Path(path).read_bytes()
-    if len(data) < 16 or not data.startswith(b"NYTPROF\0"):
+    if len(data) < 16 or data[:8] != b"NYTPROF\x00":
         raise ValueError("bad magic")
     offset = 8
     major, minor = struct.unpack_from("<II", data, offset)

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -24,7 +24,7 @@ except Exception:  # pragma: no cover - absence is fine
 __all__ = ["profile", "cli", "profile_script"]
 __version__ = "0.0.0"
 
-MAGIC = b"NYTPROF"
+_MAGIC = b"NYTPROF\x00"
 TICKS_PER_SEC = 10_000_000  # 100 ns per tick
 
 _results: Dict[int, List[int]] = {}
@@ -42,7 +42,7 @@ def _match(path: str) -> bool:
 
 def _emit_stub_file(out_path: Path) -> None:
     with out_path.open("wb") as f:
-        f.write(MAGIC + b"\0")
+        f.write(_MAGIC)
         f.write(struct.pack("<II", 5, 0))
         f.write(b"E" + struct.pack("<I", 0))
 
@@ -72,7 +72,7 @@ def _write_nytprof_py(out_path: Path) -> None:
         return
 
     with out_path.open("wb") as f:
-        f.write(MAGIC + b"\0")
+        f.write(_MAGIC)
         f.write(struct.pack("<II", 5, 0))
         f.write(_chunk("H", struct.pack("<II", 5, 0)))
         f.write(_chunk("A", a_payload))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -15,6 +15,7 @@ def test_format(tmp_path):
     env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1] / 'src')
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', str(script)], cwd=tmp_path, env=env)
     assert out.exists()
+    assert out.open('rb').read(8) == b"NYTPROF\x00"
     start = time.perf_counter()
     data = read(str(out))
     elapsed_ms = (time.perf_counter() - start) * 1000


### PR DESCRIPTION
## Summary
- write trailing NUL when writing the NYTPROF header
- use `_MAGIC` constant in tracer
- validate header exactly in reader
- check output header bytes in tests
- avoid installing recommended packages in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ed089370c8331a351820b6f54142c