### PR TITLE
Add missing major/minor after magic; tighten reader & tests

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -50,6 +50,8 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
 
     static const char MAGIC[8] = "NYTPROF\0";
     fwrite(MAGIC, 1, 8, fp);
+    uint32_t v[2] = {5, 0};
+    fwrite(v, sizeof v, 1, fp);
 
     unsigned char header[8];
     put_u32le(header, 5);

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -6,11 +6,11 @@ __all__ = ["read"]
 
 def read(path: str) -> dict:
     data = Path(path).read_bytes()
-    if len(data) < 16 or data[:8] != b"NYTPROF\x00":
-        raise ValueError("bad magic")
-    offset = 8
-    major, minor = struct.unpack_from("<II", data, offset)
-    offset += 8
+    expected = b"NYTPROF\x00" + b"\x05\x00\x00\x00" + b"\x00\x00\x00\x00"
+    if len(data) < 16 or data[:16] != expected:
+        raise ValueError("bad header")
+    major, minor = struct.unpack_from("<II", data, 8)
+    offset = 16
     result = {
         "header": (major, minor),
         "attrs": {},

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -24,7 +24,7 @@ except Exception:  # pragma: no cover - absence is fine
 __all__ = ["profile", "cli", "profile_script"]
 __version__ = "0.0.0"
 
-_MAGIC = b"NYTPROF\x00"
+_MAGIC = b"NYTPROF\x00" + (5).to_bytes(4, "little") + (0).to_bytes(4, "little")
 TICKS_PER_SEC = 10_000_000  # 100 ns per tick
 
 _results: Dict[int, List[int]] = {}
@@ -43,7 +43,6 @@ def _match(path: str) -> bool:
 def _emit_stub_file(out_path: Path) -> None:
     with out_path.open("wb") as f:
         f.write(_MAGIC)
-        f.write(struct.pack("<II", 5, 0))
         f.write(b"E" + struct.pack("<I", 0))
 
 
@@ -73,7 +72,6 @@ def _write_nytprof_py(out_path: Path) -> None:
 
     with out_path.open("wb") as f:
         f.write(_MAGIC)
-        f.write(struct.pack("<II", 5, 0))
         f.write(_chunk("H", struct.pack("<II", 5, 0)))
         f.write(_chunk("A", a_payload))
         f.write(_chunk("F", f_payload))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -15,7 +15,8 @@ def test_format(tmp_path):
     env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1] / 'src')
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', str(script)], cwd=tmp_path, env=env)
     assert out.exists()
-    assert out.open('rb').read(8) == b"NYTPROF\x00"
+    header = out.open('rb').read(16)
+    assert header == b"NYTPROF\x00" + b"\x05\x00\x00\x00" + b"\x00\x00\x00\x00"
     start = time.perf_counter()
     data = read(str(out))
     elapsed_ms = (time.perf_counter() - start) * 1000


### PR DESCRIPTION
## Summary
- write major/minor values right after `NYTPROF\0` magic in the C writer
- bundle these bytes with the magic constant in the tracer
- validate the first 16 bytes exactly in `reader.read`
- update format test for stricter header check

## Testing
- `pytest -q`
- `nytprofhtml -f nytprof.out -o report` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed289f5388331aba763c411689708