### PR TITLE
Write identical 16-byte NYTPROF header in all writers; test Python fallback

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -16,6 +16,13 @@ static void put_u64le(unsigned char *p, uint64_t v) {
     put_u32le(p + 4, (uint32_t)(v >> 32));
 }
 
+static void write_header(FILE *fp) {
+    static const char hdr[16] = "NYTPROF\0"  /* 8 bytes */
+                                "\x05\x00\x00\x00"   /* major=5 */
+                                "\x00\x00\x00\x00";  /* minor=0 */
+    fwrite(hdr, 1, 16, fp);
+}
+
 static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
     PyObject *path_obj, *files_obj, *defs_obj, *calls_obj, *lines_obj, *start_obj,
         *ticks_obj;
@@ -48,10 +55,7 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
     if (!fp)
         return PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
 
-    static const char MAGIC[8] = "NYTPROF\0";
-    fwrite(MAGIC, 1, 8, fp);
-    uint32_t v[2] = {5, 0};
-    fwrite(v, sizeof v, 1, fp);
+    write_header(fp);
 
     unsigned char header[8];
     put_u32le(header, 5);

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -4,11 +4,13 @@ from pathlib import Path
 __all__ = ["read"]
 
 
+EXPECT = b"NYTPROF\x00\x05\x00\x00\x00\x00\x00\x00\x00"
+
+
 def read(path: str) -> dict:
     data = Path(path).read_bytes()
-    expected = b"NYTPROF\x00" + b"\x05\x00\x00\x00" + b"\x00\x00\x00\x00"
-    if len(data) < 16 or data[:16] != expected:
-        raise ValueError("bad header")
+    if len(data) < 16 or data[:16] != EXPECT:
+        raise ValueError("bad header magic or version")
     major, minor = struct.unpack_from("<II", data, 8)
     offset = 16
     result = {

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,18 +5,24 @@ import time
 import os
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
-from pynytprof.reader import read
+from pynytprof.reader import read, EXPECT
 
 
-def test_format(tmp_path):
+import pytest
+
+
+@pytest.mark.parametrize("force_py", [False, True])
+def test_format(tmp_path, force_py):
     script = Path(__file__).with_name('example_script.py')
     out = tmp_path / 'nytprof.out'
-    env = dict(**os.environ)
+    env = dict(os.environ)
     env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1] / 'src')
+    if force_py:
+        env['PYNTP_FORCE_PY'] = '1'
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', str(script)], cwd=tmp_path, env=env)
     assert out.exists()
     header = out.open('rb').read(16)
-    assert header == b"NYTPROF\x00" + b"\x05\x00\x00\x00" + b"\x00\x00\x00\x00"
+    assert header == EXPECT
     start = time.perf_counter()
     data = read(str(out))
     elapsed_ms = (time.perf_counter() - start) * 1000


### PR DESCRIPTION
## Summary
- ensure C writer writes a full 16‑byte NYTPROF header using a shared function
- always build and write the 16‑byte header in the Python writer
- add EXPECT constant for header verification in `reader`
- parameterise format test to exercise Python fallback via `PYNTP_FORCE_PY`

## Testing
- `pytest -q`
- `PYTHONPATH=src PYNTP_FORCE_PY=1 python -m pynytprof.tracer tests/example_script.py`
- `nytprofhtml -f nytprof.out -o report` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eddbae0c48331886e23b5be84336f