### PR TITLE
Streamline setup.sh and add self-check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Use `convert` to generate Speedscope JSON and view results in a browser.
 ```bash
 pynytprof convert --speedscope nytprof.out
 ```
+
+## Prerequisites
+Debian/Ubuntu:  sudo ./setup.sh

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+pytest -q
+pynytprof info

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+sudo apt-get update -qq
+
+# 1. C compiler + Python headers
+sudo apt-get install --no-install-recommends -y \
+    build-essential python3-all-dev
+
+# 2. Perl NYTProf viewer + Graphviz for call-graph images
+sudo apt-get install --no-install-recommends -y \
+    libdevel-nytprof-perl graphviz


### PR DESCRIPTION
## Summary
- add a clean setup.sh for installing build tools and NYTProf viewer
- provide scripts/selfcheck.sh to run tests and show pynytprof info
- document the setup step in README

## Testing
- `./setup.sh` *(fails: repository is unreachable)*
- `scripts/selfcheck.sh` *(fails: Callgraph test error)*

------
https://chatgpt.com/codex/tasks/task_e_685ee267219c8331866b9f62ae9b0054