### PR TITLE
Enrich setup.sh: apt + venv + smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ pynytprof convert --speedscope nytprof.out
 
 ## Prerequisites
 Debian/Ubuntu:  sudo ./setup.sh
+
+## Quick start
+```bash
+bash setup.sh      # installs dependencies, builds C extensions, runs tests
+source .venv/bin/activate
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
+echo "[*] Updating apt cache"
 sudo apt-get update -qq
 
-# 1. C compiler + Python headers
+echo "[*] Installing build tool-chain, headers, Perl viewer, graphviz"
 sudo apt-get install --no-install-recommends -y \
-    build-essential python3-all-dev
-
-# 2. Perl NYTProf viewer + Graphviz for call-graph images
-sudo apt-get install --no-install-recommends -y \
+    build-essential python3-all-dev python3-venv \
     libdevel-nytprof-perl graphviz
+
+echo "[*] Creating virtual environment .venv"
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "[*] Upgrading pip & wheel, installing project"
+pip install --upgrade pip wheel >/dev/null
+pip install -e .  # builds _tracer / _writer C extensions
+
+echo "[*] Running smoke test"
+pytest -q
+pynytprof info
+
+echo "[✓] Environment ready — activate with:  source .venv/bin/activate"


### PR DESCRIPTION
## Summary
- expand setup script with tool-chain install and smoke test
- document quick start in README

## Testing
- `bash setup.sh` *(fails: repository apt sources 403)*
- `pytest -q` *(fails: nytprofhtml not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ee512ab3483318e9f084dbcb107f4