### PR TITLE
Write unified 16-byte NYTPROF header in both writers; assert in tests

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -17,9 +17,8 @@ static void put_u64le(unsigned char *p, uint64_t v) {
 }
 
 static void write_header(FILE *fp) {
-    static const char hdr[16] = "NYTPROF\0"  /* 8 bytes */
-                                "\x05\x00\x00\x00"   /* major=5 */
-                                "\x00\x00\x00\x00";  /* minor=0 */
+    static const unsigned char hdr[16] =
+        "NYTPROF\0" "\x05\x00\x00\x00" "\x00\x00\x00\x00";
     fwrite(hdr, 1, 16, fp);
 }
 
@@ -56,10 +55,6 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
         return PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
 
     write_header(fp);
-
-    unsigned char header[8];
-    put_u32le(header, 5);
-    put_u32le(header + 4, 0);
 
     unsigned char hchunk[13];
     hchunk[0] = 'H';
@@ -228,7 +223,6 @@ static PyObject *pynytprof_write(PyObject *self, PyObject *args) {
     echunk[0] = 'E';
     put_u32le(echunk + 1, 0);
 
-    fwrite(header, 8, 1, fp);
     fwrite(hchunk, 13, 1, fp);
     fwrite(achunk, 5 + a_len, 1, fp);
     fwrite(fchunk, 5 + f_len, 1, fp);

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -9,12 +9,11 @@ EXPECT = b"NYTPROF\x00\x05\x00\x00\x00\x00\x00\x00\x00"
 
 def read(path: str) -> dict:
     data = Path(path).read_bytes()
-    if len(data) < 16 or data[:16] != EXPECT:
-        raise ValueError("bad header magic or version")
-    major, minor = struct.unpack_from("<II", data, 8)
+    if data[:16] != EXPECT:
+        raise ValueError("bad header")
     offset = 16
     result = {
-        "header": (major, minor),
+        "header": (5, 0),
         "attrs": {},
         "files": {},
         "records": [],
@@ -38,7 +37,7 @@ def read(path: str) -> dict:
             if length != 8:
                 raise ValueError("bad H length")
             h_major, h_minor = struct.unpack_from("<II", payload)
-            if (h_major, h_minor) != (major, minor):
+            if (h_major, h_minor) != (5, 0):
                 raise ValueError("header mismatch")
         elif tok == "A":
             if not payload or payload[-1] != 0:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,7 +5,7 @@ import time
 import os
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
-from pynytprof.reader import read, EXPECT
+from pynytprof.reader import read
 
 
 import pytest
@@ -21,8 +21,8 @@ def test_format(tmp_path, force_py):
         env['PYNTP_FORCE_PY'] = '1'
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', str(script)], cwd=tmp_path, env=env)
     assert out.exists()
-    header = out.open('rb').read(16)
-    assert header == EXPECT
+    expected = b'NYTPROF\x00\x05\x00\x00\x00\x00\x00\x00\x00'
+    assert out.open('rb').read(16) == expected
     start = time.perf_counter()
     data = read(str(out))
     elapsed_ms = (time.perf_counter() - start) * 1000


### PR DESCRIPTION
## Summary
- ensure C writer emits standard 16‑byte header
- tighten reader check and store fixed header values
- expect fixed bytes in format test

## Testing
- `pytest -q` *(fails: test_callgraph)*

------
https://chatgpt.com/codex/tasks/task_e_685ee69b231c83319c29685c61c8425e