### PR TITLE
Write uniform 16-byte NYTPROF header; extend setup.sh with perl-doc & tools

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,24 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[*] Updating apt cache"
 sudo apt-get update -qq
-
-echo "[*] Installing build tool-chain, headers, Perl viewer, graphviz"
 sudo apt-get install --no-install-recommends -y \
     build-essential python3-all-dev python3-venv \
-    libdevel-nytprof-perl graphviz
+    libdevel-nytprof-perl perl-doc graphviz \
+    vim-common coreutils  # xxd and od
 
-echo "[*] Creating virtual environment .venv"
 python3 -m venv .venv
 source .venv/bin/activate
-
-echo "[*] Upgrading pip & wheel, installing project"
 pip install --upgrade pip wheel >/dev/null
-pip install -e .  # builds _tracer / _writer C extensions
+pip install -e .
 
-echo "[*] Running smoke test"
 pytest -q
 pynytprof info
-
-echo "[✓] Environment ready — activate with:  source .venv/bin/activate"
+echo "[✓] Ready — activate via:  source .venv/bin/activate"

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -17,9 +17,9 @@ static void put_u64le(unsigned char *p, uint64_t v) {
 }
 
 static void write_header(FILE *fp) {
-    static const unsigned char hdr[16] =
-        "NYTPROF\0" "\x05\x00\x00\x00" "\x00\x00\x00\x00";
-    fwrite(hdr, 1, 16, fp);
+    static const unsigned char HDR[16] =
+        "NYTPROF\0" "\x05\0\0\0" "\0\0\0\0";
+    fwrite(HDR, 1, 16, fp);
 }
 
 static PyObject *pynytprof_write(PyObject *self, PyObject *args) {

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -1,15 +1,16 @@
 import struct
 from pathlib import Path
+from .tracer import _HDR
 
 __all__ = ["read"]
 
 
-EXPECT = b"NYTPROF\x00\x05\x00\x00\x00\x00\x00\x00\x00"
+EXPECTED = _HDR
 
 
 def read(path: str) -> dict:
     data = Path(path).read_bytes()
-    if data[:16] != EXPECT:
+    if data[:16] != EXPECTED:
         raise ValueError("bad header")
     offset = 16
     result = {

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -24,7 +24,7 @@ except Exception:  # pragma: no cover - absence is fine
 __all__ = ["profile", "cli", "profile_script"]
 __version__ = "0.0.0"
 
-_HDR = b"NYTPROF\x00" + (5).to_bytes(4, "little") + (0).to_bytes(4, "little")
+_HDR = b'NYTPROF\x00' + (5).to_bytes(4,'little') + (0).to_bytes(4,'little')
 TICKS_PER_SEC = 10_000_000  # 100 ns per tick
 
 _results: Dict[int, List[int]] = {}

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -18,6 +18,8 @@ def test_callgraph(tmp_path):
         "pynytprof.tracer",
         str(script),
     ], cwd=tmp_path, env=env)
+    with open(tmp_path / 'nytprof.out', 'rb') as fh:
+        print("HDR", fh.read(16).hex(), file=sys.stderr)
     subprocess.check_call(["nytprofhtml", "-f", "nytprof.out"], cwd=tmp_path)
     html = (tmp_path / "nytprof" / "index.html").read_text()
     assert "cg_example.py->foo" in html


### PR DESCRIPTION
## Summary
- write uniform NYTPROF header constant in C writer
- use same `_HDR` constant when writing from Python and when reading
- adjust format test for EXPECTED header constant
- print header before running `nytprofhtml` in callgraph test
- enrich setup script with perl-doc and helpful utilities

## Testing
- `pytest -q` *(fails: NYTProf data format error while reading header)*

------
https://chatgpt.com/codex/tasks/task_e_685eeab3e5588331bea3c2a2d7ecbae5