### PR TITLE
Add Makefile with build / test / profile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+VENV?=.venv
+BIN=$(VENV)/bin
+PY=$(BIN)/python
+
+.PHONY: venv build test profile html info
+
+venv:
+	python3 -m venv $(VENV)
+	$(PY) -m pip install -U pip wheel
+
+build: venv
+	$(PY) -m pip install -e .
+
+test: build
+	$(BIN)/pytest -q
+
+profile: build
+	$(PY) -m pynytprof.tracer tests/example_script.py
+
+html: profile
+	nytprofhtml -f nytprof.out -o report
+
+info:
+	$(PY) -m pip list


### PR DESCRIPTION
## Summary
- add a Makefile for common developer tasks

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement wheel)*
- `make profile` *(fails: Could not find a version that satisfies the requirement wheel)*
- `make html` *(fails: Could not find a version that satisfies the requirement wheel)*

------
https://chatgpt.com/codex/tasks/task_e_685f09e4e93083319965a0914235510c