### PR TITLE
Fix H-chunk and add minimal viewer test

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -23,12 +23,12 @@ static void write_header(FILE *fp) {
 }
 
 static void write_H_chunk(FILE *fp) {
-    unsigned char h[13];
-    h[0] = 'H';
-    put_u32le(h + 1, 8);   /* payload length */
-    put_u32le(h + 5, 5);   /* major version */
-    put_u32le(h + 9, 0);   /* minor version */
-    fwrite(h, 1, sizeof h, fp);
+    static const unsigned char H[13] =
+        "H" /* token */
+        "\x08\x00\x00\x00" /* u32 length = 8 */
+        "\x05\x00\x00\x00" /* u32 major = 5 */
+        "\x00\x00\x00\x00"; /* u32 minor = 0 */
+    fwrite(H, 1, sizeof H, fp);
 }
 
 static PyObject *pynytprof_write(PyObject *self, PyObject *args) {

--- a/tests/test_viewer_minimal.py
+++ b/tests/test_viewer_minimal.py
@@ -1,0 +1,26 @@
+import os, shutil, subprocess, sys
+from pathlib import Path
+import pytest
+
+HELLO = 'print("hello")\n'
+
+def test_viewer_minimal(tmp_path):
+    if not shutil.which("nytprofhtml"):
+        pytest.skip("nytprofhtml missing")
+
+    script = tmp_path / "hello.py"
+    script.write_text(HELLO)
+
+    env = dict(os.environ)
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", str(script)],
+        cwd=tmp_path,
+        env=env,
+    )
+
+    subprocess.check_call(
+        ["nytprofhtml", "-f", "nytprof.out", "-o", "report"],
+        cwd=tmp_path,
+    )
+
+    assert (tmp_path / "report" / "index.html").exists()


### PR DESCRIPTION
## Summary
- add a minimal round‑trip test ensuring `nytprofhtml` can open output
- correct the C writer to emit the H‑chunk with a static byte array

## Testing
- `pytest -q` *(fails: NYTProf data format error; ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685f175073e08331b793e66b792f4421