### PR TITLE
Fix extension name and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pynytprof your_script.py
 nytprofhtml -f nytprof.out
 ```
 
-Current status: MVP writes only H A F S E chunks.
+Current status: files include H, A, F, D, C, S and E chunks.
 
 ## Selective profiling
 Set `NYTPROF_FILTER` to a comma separated list of glob patterns.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ## Data path
 
-CPython frame-eval -> `tracer.py` gathers line events -> `_writer.c` packs structs and
-spills to `nytprof.out` -> Perl `nytprofhtml` -> HTML.
+CPython frame-eval -> `tracer.py` gathers line events -> `_writer.c` packs structs
+and writes `nytprof.out` -> Perl `nytprofhtml` -> HTML.
 
 `tracer.py` stays pure Python so users can prototype quickly, while the C writer handles the
 hot loop so overhead stays under 5×.
@@ -11,7 +11,7 @@ hot loop so overhead stays under 5×.
 | Module      | Responsibility                           |
 |-------------|------------------------------------------|
 | `tracer.py` | subscribe to frame events, queue records |
-| `_writer.c` | ring buffer + `write()` burst flush      |
+| `_writer.c` | collect structures and write chunks      |
 | `reader.py` | (dev-only) decode records for tests      |
 
 Call depth comes from `frame->f_depth`. Wall-clock ticks use `clock_gettime(CLOCK_MONOTONIC_RAW)`

--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -28,8 +28,8 @@ chunk[] (see below)
 | `S`   | repeat `{u32 fid,u32 line, u32 calls, u64 inc_ticks, u64 exc_ticks}` | one record per executed line                                     |
 | `E`   | empty                                                        | terminator                                                        |
 
-Skip call-graph chunks (`C`,`D`) for now. `nytprofhtml` still renders per-line heat maps. If the
-reader complains, look for "File format error: token X".
+Call-graph chunks (`C`,`D`) are included so that `nytprofhtml` can render call graphs.
+If the reader complains, look for "File format error: token X".
 
 ### Tick units
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     packages=['pynytprof'],
     package_dir={'': 'src'},
     ext_modules=[
-        Extension('pynytprof._writer', ['src/pynytprof/_writer.c']),
+        Extension('pynytprof._cwrite', ['src/pynytprof/_writer.c']),
         Extension('pynytprof._tracer', ['src/pynytprof/_tracer.c']),
     ],
     entry_points={'console_scripts': ['pynytprof=pynytprof.__main__:cli']},

--- a/src/pynytprof/__init__.py
+++ b/src/pynytprof/__init__.py
@@ -1,28 +1,5 @@
-"""
-Minimal tracer: runs a script and produces an empty NYTProf file
-so the quick-start command line works. Replace logic later.
-"""
+"""Pynytprof package public API wrappers."""
+from .tracer import profile_script, profile, cli
 
-import runpy
-import sys
-from pathlib import Path
+__all__ = ["profile_script", "profile", "cli"]
 
-MAGIC = b'NYTPROF'  # 8 bytes incl. trailing NULL in NYTProf, we add later
-
-def _emit_stub_file(out_path: Path) -> None:
-    with out_path.open('wb') as f:
-        f.write(MAGIC + b'\0')        # "NYTPROF\0"
-        f.write((5).to_bytes(4, 'little'))  # major
-        f.write((0).to_bytes(4, 'little'))  # minor
-        f.write(b'E' + (0).to_bytes(4, 'little'))  # empty E-chunk
-
-def profile_script(path: str) -> None:
-    out = Path('nytprof.out')
-    _emit_stub_file(out)
-    runpy.run_path(path, run_name='__main__')
-
-def cli() -> None:
-    if len(sys.argv) != 2:
-        print('Usage: pynytprof <script.py>', file=sys.stderr)
-        sys.exit(1)
-    profile_script(sys.argv[1])


### PR DESCRIPTION
## Summary
- build the C writer extension as `_cwrite`
- document that call-graph chunks are produced
- clarify writer description in ARCHITECTURE doc
- remove obsolete stub in `__init__` and re-export tracer API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2240585c833185d047e2d1438771