### PR TITLE
Ensure nytprofhtml can view NYTProf output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pynytprof convert --speedscope nytprof.out
 
 ## Prerequisites
 Debian/Ubuntu:  sudo ./setup.sh
+Running the HTML round-trip test requires `cpanm Devel::NYTProf`
 
 ## Quick start
 ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths =
+    tests
+    integration

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -12,23 +12,32 @@ from fnmatch import fnmatch
 from types import FrameType
 from typing import Any, Dict, List
 
+_force_py = bool(os.environ.get("PYNTP_FORCE_PY"))
+
 _write = None
-for _mod in ("_cwrite", "_writer", "_pywrite"):
+if _force_py:
     try:
-        _write = importlib.import_module(f"pynytprof.{_mod}").write
-        break
-    except ModuleNotFoundError:  # pragma: no cover - optional
-        continue
+        _write = importlib.import_module("pynytprof._pywrite").write
+    except ModuleNotFoundError:
+        _write = None
+else:
+    for _mod in ("_cwrite", "_writer", "_pywrite"):
+        try:
+            _write = importlib.import_module(f"pynytprof.{_mod}").write
+            break
+        except ModuleNotFoundError:  # pragma: no cover - optional
+            continue
 if _write is None:  # pragma: no cover - should ship with at least _pywrite
     raise ImportError("No nyprof writer available")
 
 _ctrace = None
-for _mod in ("_tracer", "_ctrace"):
-    try:
-        _ctrace = importlib.import_module(f"pynytprof.{_mod}")
-        break
-    except ModuleNotFoundError:  # pragma: no cover - optional
-        continue
+if not _force_py:
+    for _mod in ("_tracer", "_ctrace"):
+        try:
+            _ctrace = importlib.import_module(f"pynytprof.{_mod}")
+            break
+        except ModuleNotFoundError:  # pragma: no cover - optional
+            continue
 
 __all__ = ["profile", "cli", "profile_script"]
 __version__ = "0.0.0"

--- a/tests/test_integration_html.py
+++ b/tests/test_integration_html.py
@@ -1,0 +1,46 @@
+import pathlib
+import shutil
+import subprocess
+import importlib
+import pytest
+
+from pynytprof import tracer
+
+NYTPROFHTML = shutil.which('nytprofhtml')
+
+pytestmark = pytest.mark.skipif(
+    NYTPROFHTML is None,
+    reason='Devel::NYTProf not installed'
+)
+
+
+def make_sample_script(tmp: pathlib.Path) -> pathlib.Path:
+    code = (
+        "def fib(n):\n"
+        "    return 1 if n < 2 else fib(n-1) + fib(n-2)\n"
+        "fib(8)\n"
+    )
+    p = tmp / 'sample.py'
+    p.write_text(code)
+    return p
+
+
+def test_nytprofhtml_roundtrip(tmp_path, monkeypatch):
+    script = make_sample_script(tmp_path)
+
+    # force pure-Python mode
+    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
+    importlib.reload(tracer)
+    monkeypatch.chdir(tmp_path)
+
+    tracer.profile_script(str(script))
+    out = tmp_path / 'nytprof.out'
+    assert out.exists(), 'profiling produced no output file'
+
+    res = subprocess.run(
+        [NYTPROFHTML, '--out', tmp_path / 'html', str(out)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert res.returncode == 0, res.stderr.decode()
+    assert (tmp_path / 'html' / 'index.html').exists()


### PR DESCRIPTION
## Summary
- add optional dependency note for HTML round-trip testing
- make tracer respect `PYNTP_FORCE_PY` to bypass C extensions
- add an integration test that round-trips output through `nytprofhtml`
- ensure pytest collects integration tests by default

## Testing
- `pip install -e '.[dev]'` *(fails: Could not install build dependencies)*
- `pytest -q` *(fails: nytprofhtml reported `NYTProf data format error`)*

------
https://chatgpt.com/codex/tasks/task_e_6869506a815c8331946a190ec1d7ea2b