### PR TITLE
feat: add stub for _native extension

### DIFF
--- a/src/pynytprof/_native.pyi
+++ b/src/pynytprof/_native.pyi
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+
+
+def enable(path: str, start_ns: int) -> None: ...
+
+
+def dump() -> tuple[list[tuple[int, str, int, int, str]], list[tuple[Optional[str], int, int, int, int]], list[tuple[str, int, int, int, int]]]: ...
+
+
+def write(
+    out_path: str,
+    files: list[tuple[int, int, int, int, str]],
+    defs: list[tuple[int, int, int, int, str]],
+    calls: list[tuple[int | None, int, int, int, int]],
+    lines: list[tuple[int, int, int, int, int]],
+    start_ns: int,
+    ticks_per_sec: int,
+) -> None: ...


### PR DESCRIPTION
## Summary
- add type hints for the native C extension

## Testing
- `ruff check src/pynytprof tests` *(fails: F401, E401)*
- `mypy --strict src/pynytprof` *(fails: found 29 errors)*
- `pytest -q` *(fails: 4 failed, 10 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6869594125c48331b0eaee735213a810