### PR TITLE
Implement zlib compression for NYTProf heavy chunks

### DIFF
--- a/src/pynytprof/writer.py
+++ b/src/pynytprof/writer.py
@@ -4,6 +4,7 @@ import os
 import struct
 import time
 from pathlib import Path
+import zlib
 
 __all__ = ["Writer"]
 
@@ -18,6 +19,26 @@ class Writer:
         self._path = Path(path)
         self._fh: os.PathLike | None = None
         self._header_written = False
+        self._header_bytes = b""
+        self._compressed_used = False
+
+    def _compress(self, tag: bytes, data: bytes) -> bytes:
+        if data and tag in {b"F", b"D", b"C", b"S"}:
+            self._compressed_used = True
+            return zlib.compress(data, 6)
+        return data
+
+    def _add_compressed_flag(self) -> None:
+        data = self._path.read_bytes()
+        rest = data[len(self._header_bytes) :]
+        lines = self._header_bytes.rstrip(b"\n").split(b"\n")
+        if lines and lines[-1] == b"":
+            lines = lines[:-1]
+        lines.append(b"compressed=1")
+        lines.append(b"")
+        new_header = b"\n".join(lines) + b"\n"
+        self._path.write_bytes(new_header + rest)
+        self._header_bytes = new_header
 
     def __enter__(self) -> "Writer":
         self._fh = self._path.open("wb")
@@ -28,6 +49,8 @@ class Writer:
         if self._fh:
             self._fh.close()
         self._fh = None
+        if self._compressed_used and b"compressed=1\n" not in self._header_bytes:
+            self._add_compressed_flag()
         self._header_written = False
 
     def _write_text_header(self) -> None:
@@ -39,15 +62,19 @@ class Writer:
             "ticks_per_sec=1000000000",
             f"process_id={os.getpid()}",
             f"start_time={int(time.time())}",
-            "",
         ]
-        for line in lines:
-            self._fh.write(line.encode("ascii") + b"\n")
+        if self._compressed_used:
+            lines.append("compressed=1")
+        lines.append("")
+        header = b"\n".join(line.encode("ascii") for line in lines) + b"\n"
+        self._fh.write(header)
+        self._header_bytes = header
         self._header_written = True
 
     def _write_chunk(self, tag: bytes, payload: bytes) -> None:
         if self._fh is None:
             raise ValueError("writer not opened")
+        payload = self._compress(tag, payload)
         self._fh.write(tag)
         self._fh.write(struct.pack("<I", len(payload)))
         if payload:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,3 +1,6 @@
+import struct
+
+import pytest
 from pynytprof.writer import Writer
 
 
@@ -7,3 +10,25 @@ def test_text_header(tmp_path):
         pass
     first = open(out, "rb").read().split(b"\n")[0]
     assert first == b"file=" + str(out).encode()
+
+
+@pytest.mark.parametrize(
+    "tag,data",
+    [
+        (b"F", b"x" * 100),
+        (b"D", b"y" * 120),
+        (b"C", b"z" * 80),
+        (b"S", b"w" * 160),
+    ],
+)
+def test_chunk_compression(tmp_path, tag, data):
+    out = tmp_path / "out.nyt"
+    with Writer(str(out)) as w:
+        w._write_chunk(tag, data)
+    buf = out.read_bytes()
+    hdr_end = buf.index(b"\n\n") + 2
+    on_disk = buf[hdr_end:]
+    assert on_disk[0:1] == tag
+    payload_len = struct.unpack("<I", on_disk[1:5])[0]
+    payload = on_disk[5 : 5 + payload_len]
+    assert len(payload) < len(data)


### PR DESCRIPTION
## Summary
- add optional compression of F, D, C and S chunks using zlib
- write `compressed=1` in header when such chunks are present
- test that heavy chunks get compressed on disk

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9c03ec448331bef564e1e8fb3f12