### PR TITLE
Add NYTProf string table support

### DIFF
--- a/src/pynytprof/writer.py
+++ b/src/pynytprof/writer.py
@@ -8,8 +8,29 @@ import zlib
 
 __all__ = ["Writer"]
 
+TAG_T = b"T"
+
 PREFIX = b"NYTPROF\0"
 VERSION = 5
+
+
+class _StringTable:
+    def __init__(self) -> None:
+        self._strings: dict[str, int] = {}
+
+    def add(self, s: str) -> int:
+        if s not in self._strings:
+            self._strings[s] = len(self._strings)
+        return self._strings[s]
+
+    def serialize(self) -> bytes:
+        out = bytearray()
+        out.extend(struct.pack("<I", len(self._strings)))
+        for s in self._strings:
+            b = s.encode("utf-8")
+            out.extend(struct.pack("<I", len(b)))
+            out.extend(b)
+        return bytes(out)
 
 
 class Writer:
@@ -21,20 +42,30 @@ class Writer:
         self._header_written = False
         self._header_bytes = b""
         self._compressed_used = False
+        self._table = _StringTable()
+        self._table_written = False
 
     def _compress(self, tag: bytes, data: bytes) -> bytes:
-        if data and tag in {b"F", b"D", b"C", b"S"}:
+        if not data:
+            return data
+        if tag in {b"F", b"D", b"C", b"S"}:
+            self._compressed_used = True
+            return zlib.compress(data, 6)
+        if tag == TAG_T and len(data) > 1024:
             self._compressed_used = True
             return zlib.compress(data, 6)
         return data
 
-    def _add_compressed_flag(self) -> None:
+    def _rewrite_header(self) -> None:
         data = self._path.read_bytes()
         rest = data[len(self._header_bytes) :]
         lines = self._header_bytes.rstrip(b"\n").split(b"\n")
         if lines and lines[-1] == b"":
             lines = lines[:-1]
-        lines.append(b"compressed=1")
+        if self._compressed_used and b"compressed=1" not in lines:
+            lines.append(b"compressed=1")
+        lines.append(b"stringtable=present")
+        lines.append(f"stringcount={len(self._table._strings)}".encode("ascii"))
         lines.append(b"")
         new_header = b"\n".join(lines) + b"\n"
         self._path.write_bytes(new_header + rest)
@@ -47,10 +78,12 @@ class Writer:
 
     def __exit__(self, exc_type, exc, tb) -> None:
         if self._fh:
+            if not self._table_written:
+                self._write_chunk(TAG_T, self._table.serialize())
+                self._table_written = True
             self._fh.close()
         self._fh = None
-        if self._compressed_used and b"compressed=1\n" not in self._header_bytes:
-            self._add_compressed_flag()
+        self._rewrite_header()
         self._header_written = False
 
     def _write_text_header(self) -> None:
@@ -79,3 +112,26 @@ class Writer:
         self._fh.write(struct.pack("<I", len(payload)))
         if payload:
             self._fh.write(payload)
+
+    def _ensure_table(self) -> None:
+        if not self._table_written:
+            self._write_chunk(TAG_T, self._table.serialize())
+            self._table_written = True
+
+    def _write_file_chunk(self, records: list[tuple[int, int, int, int, str]]) -> None:
+        self._ensure_table()
+        payload = bytearray()
+        for fid, flags, size, mtime, path in records:
+            payload.extend(struct.pack("<IIII", fid, flags, size, mtime))
+            idx = self._table.add(path)
+            payload.extend(struct.pack("<I", idx))
+        self._write_chunk(b"F", bytes(payload))
+
+    def _write_sub_chunk(self, records: list[tuple[int, int, int, int, str]]) -> None:
+        self._ensure_table()
+        payload = bytearray()
+        for sid, fid, sl, el, name in records:
+            payload.extend(struct.pack("<IIII", sid, fid, sl, el))
+            idx = self._table.add(name)
+            payload.extend(struct.pack("<I", idx))
+        self._write_chunk(b"D", bytes(payload))

--- a/tests/test_stringtable.py
+++ b/tests/test_stringtable.py
@@ -1,0 +1,23 @@
+import struct
+
+from pynytprof.writer import _StringTable
+
+
+def test_stringtable_roundtrip():
+    tbl = _StringTable()
+    assert tbl.add("foo") == 0
+    assert tbl.add("bar") == 1
+    assert tbl.add("foo") == 0
+    payload = tbl.serialize()
+    count = struct.unpack_from("<I", payload)[0]
+    assert count == 2
+    offset = 4
+    out = []
+    for _ in range(count):
+        length = struct.unpack_from("<I", payload, offset)[0]
+        offset += 4
+        s = payload[offset : offset + length].decode()
+        offset += length
+        out.append(s)
+    assert out == ["foo", "bar"]
+    assert offset == len(payload)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 import struct
+import zlib
 
 import pytest
 from pynytprof.writer import Writer
@@ -32,3 +33,25 @@ def test_chunk_compression(tmp_path, tag, data):
     payload_len = struct.unpack("<I", on_disk[1:5])[0]
     payload = on_disk[5 : 5 + payload_len]
     assert len(payload) < len(data)
+
+
+def test_file_chunk_uses_string_indexes(tmp_path):
+    out = tmp_path / "out.nyt"
+    with Writer(str(out)) as w:
+        w._write_file_chunk([(0, 0x10, 123, 0, "foo.py")])
+    buf = out.read_bytes()
+    hdr_end = buf.index(b"\n\n") + 2
+    after = buf[hdr_end:]
+    assert after[0:1] == b"T"
+    t_len = struct.unpack_from("<I", after, 1)[0]
+    offset = 5 + t_len
+    assert after[offset : offset + 1] == b"F"
+    f_len = struct.unpack_from("<I", after, offset + 1)[0]
+    payload = after[offset + 5 : offset + 5 + f_len]
+    payload = zlib.decompress(payload)
+    assert len(payload) == 20
+    _, _, _, _, idx = struct.unpack("<IIIII", payload)
+    assert idx == 0
+    header_lines = buf[: hdr_end - 2].split(b"\n")
+    assert b"stringtable=present" in header_lines
+    assert b"stringcount=1" in header_lines


### PR DESCRIPTION
## Summary
- intern strings in writer via `_StringTable`
- serialize table in `TAG_T` chunk and update header
- compress large string tables
- update writer to emit indexes in file chunks
- add tests for `_StringTable` and new writer behaviour

## Testing
- `ruff check tests/test_stringtable.py tests/test_writer.py src/pynytprof/writer.py`
- `black --line-length 99 tests/test_writer.py tests/test_stringtable.py src/pynytprof/writer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9e531c988331b591943f7ecf203a