### PR TITLE
Add NYTProf statement chunk

### DIFF
--- a/tests/test_perl_lines.py
+++ b/tests/test_perl_lines.py
@@ -1,0 +1,36 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+
+def test_perl_lines(tmp_path):
+    if not shutil.which("perl"):
+        pytest.skip("perl missing")
+    script = Path(__file__).with_name("example_script.py")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pynytprof.tracer",
+            str(script),
+        ],
+        cwd=tmp_path,
+        env=env,
+    )
+    out_file = tmp_path / "nytprof.out"
+    cmd = [
+        "perl",
+        "-MDevel::NYTProf::Data",
+        "-e",
+        "print Devel::NYTProf::Data->new(shift)->lines",
+        str(out_file),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        pytest.skip("NYTProf Perl module missing")
+    assert int(res.stdout.strip()) > 0


### PR DESCRIPTION
## Summary
- write TAG_D statement records in writer
- expose has_stmt=1 in header
- test Writer with mmap on D chunk
- add integration test using `Devel::NYTProf::Data`

## Testing
- `ruff check --fix tests/test_writer.py tests/test_perl_lines.py`
- `black --line-length 99 tests/test_writer.py tests/test_perl_lines.py`
- `ruff check src/pynytprof/writer.py`
- `black --line-length 99 src/pynytprof/writer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba2b3ad908331adda174e8f9890f2