### PR TITLE
Implement callgraph C chunk

### DIFF
--- a/tests/test_callgraph_chunk.py
+++ b/tests/test_callgraph_chunk.py
@@ -1,0 +1,40 @@
+import mmap
+import struct
+import zlib
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from pynytprof.writer import Writer
+
+
+def test_callgraph_chunk(tmp_path):
+    out = tmp_path / "out.nyt"
+    with Writer(str(out)) as w:
+        fid = w.add_file(str(out), True)
+        caller = w.sub_table.add(fid, 1, 2, "caller", "pkg")
+        callee = w.sub_table.add(fid, 3, 4, "callee", "pkg")
+        for _ in range(3):
+            w.callgraph.add(caller, callee, 10)
+    with out.open("rb") as fh:
+        mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+        hdr_end = mm.find(b"\n\n") + 2
+        off = hdr_end
+        found = False
+        while off < mm.size():
+            tag = mm[off:off+1]
+            length = struct.unpack_from("<I", mm, off+1)[0]
+            off += 5
+            payload = mm[off:off+length]
+            off += length
+            if tag == b"C":
+                payload = zlib.decompress(payload)
+                vals = struct.unpack_from("<III", payload, 0)
+                assert vals == (caller, callee, 3)
+                found = True
+                break
+        mm.close()
+    assert found
+    lines = out.read_bytes().split(b"\n")
+    assert b"callgraph=present" in lines
+    assert b"edgecount=1" in lines

--- a/tests/test_perl_callgraph.py
+++ b/tests/test_perl_callgraph.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+from pynytprof.writer import Writer
+
+
+def test_perl_callgraph(tmp_path):
+    if not shutil.which("perl"):
+        pytest.skip("perl missing")
+    out = tmp_path / "out.nyt"
+    with Writer(str(out)) as w:
+        fid = w.add_file(str(out), True)
+        a = w.sub_table.add(fid, 1, 1, "a", "m")
+        b = w.sub_table.add(fid, 2, 2, "b", "m")
+        w.callgraph.add(a, b, 5)
+    cmd = [
+        "perl",
+        "-MDevel::NYTProf::Data",
+        "-e",
+        "print Devel::NYTProf::Data->new(shift)->calls",
+        str(out),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        pytest.skip("NYTProf Perl module missing")
+    assert int(res.stdout.strip()) == 1


### PR DESCRIPTION
## Summary
- add `_CallGraph` helper to collect edge data
- write callgraph chunk in `Writer.close()`
- expose callgraph info in ASCII header
- test callgraph serialization and Perl integration

## Testing
- `pytest tests/test_callgraph_chunk.py::test_callgraph_chunk -q`
- `pytest tests/test_perl_callgraph.py::test_perl_callgraph -q` *(skipped: perl missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba89b8ee083319a984d4289ce1d81