### PR TITLE
Implement proper NYTProf binary header

### DIFF
--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,0 +1,24 @@
+import subprocess
+import struct
+
+import pytest
+
+from pynytprof.writer import Writer, _MAGIC, _MAJOR, _MINOR
+
+
+def test_binary_header(tmp_path):
+    out = tmp_path / "out.nyt"
+    with Writer(str(out)):
+        pass
+    data = out.read_bytes()[:32]
+    expected = _MAGIC + struct.pack("<II", _MAJOR, _MINOR)
+    assert data.startswith(expected)
+    assert data[16:21] == b"file="
+    res = subprocess.run([
+        "perl",
+        "-MDevel::NYTProf::Data",
+        "-e",
+        "exit 0",
+        str(out),
+    ])
+    assert res.returncode == 0

--- a/tests/test_subtable.py
+++ b/tests/test_subtable.py
@@ -38,7 +38,8 @@ def test_subtable_chunk(tmp_path):
                 break
         mm.close()
     assert found
-    header_lines = out.read_bytes().split(b"\n")
+    data = out.read_bytes()
+    header_lines = data[16:].split(b"\n")
     assert b"subcount=2" in header_lines
     assert b"has_subs=1" in header_lines
 


### PR DESCRIPTION
## Summary
- write a standards-compliant NYTProf v5 header in `Writer`
- update tests expecting the old header
- add regression test for binary header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb933fab48331b31d1ba912bf46d4