### PR TITLE
Simplify header writing

### DIFF
--- a/src/pynytprof/writer.py
+++ b/src/pynytprof/writer.py
@@ -121,7 +121,6 @@ class Writer:
         self._path = Path(path)
         self._fh: os.PathLike | None = None
         self._header_written = False
-        self._header_bytes = b""
         self._compressed_used = False
         self._ticks_per_sec = 1_000_000_000
         self._start_time = 0
@@ -197,39 +196,22 @@ class Writer:
             flags,
         )
 
-    def _fix_header(self) -> None:
-        data = self._path.read_bytes()
-        rest = data[len(self._header_bytes) :]
-        header_magic = _MAGIC + struct.pack("<II", _MAJOR, _MINOR)
-        lines = self._header_bytes[len(header_magic) :].rstrip(b"\n").split(b"\n")
-        lines = [l for l in lines if l and not l.startswith(b"file=")]
-        lines.insert(0, f"file={self._path}".encode("ascii"))
-        if self._compressed_used and b"compressed=1" not in lines:
-            lines.append(b"compressed=1")
-        if b"has_stmt=1" not in lines:
-            lines.append(b"has_stmt=1")
-        if b"has_subs=1" not in lines:
-            lines.append(b"has_subs=1")
-        if self._callgraph and len(self._callgraph) > 0:
-            if b"callgraph=present" not in lines:
-                lines.append(b"callgraph=present")
-            lines.append(f"edgecount={len(self._callgraph)}".encode("ascii"))
-        if self.stats:
-            lines.append(b"has_attrs=1")
-            lines.append(f"attrcount={len(self.stats)}".encode("ascii"))
-        lines.append(b"has_end=1")
-        lines.append(f"filecount={self._file_count}".encode("ascii"))
-        lines.append(f"subcount={self._sub_table.count}".encode("ascii"))
-        lines.append(b"stringtable=present")
-        lines.append(f"stringcount={len(self._table._strings)}".encode("ascii"))
-        new_ascii = b"\n".join(lines) + b"\n\n"
-        new_header = header_magic + new_ascii
-        self._path.write_bytes(new_header + rest)
-        self._header_bytes = new_header
+    def _build_attrs(self) -> bytes:
+        lines = [
+            f"file={self._path}",
+            "version=5",
+            f"ticks_per_sec={self._ticks_per_sec}",
+            f"start_time={int(self._start_time)}",
+        ]
+        if self._compressed_used:
+            lines.append("compressed=1")
+        return ("\n".join(lines) + "\n\n").encode("ascii")
+
 
     def __enter__(self) -> "Writer":
         self._fh = self._path.open("wb")
         self._start_ns = time.time_ns()
+        self._start_time = time.time()
         self._write_header()
         return self
 
@@ -260,26 +242,15 @@ class Writer:
             self._write_chunk(b"E", struct.pack("<Q", end_ns))
             self._fh.close()
         self._fh = None
-        self._fix_header()
         self._header_written = False
 
     def _write_header(self) -> None:
         if self._header_written or self._fh is None:
             return
-        self._start_time = int(time.time())
-        attrs = [
-            f"file={self._path}",
-            "version=5",
-            f"ticks_per_sec={self._ticks_per_sec}",
-            f"start_time={self._start_time}",
-        ]
-        if self._compressed_used:
-            attrs.append("compressed=1")
-        ascii_hdr = ("\n".join(attrs) + "\n\n").encode("ascii")
+        ascii_hdr = self._build_attrs()
         self._fh.write(_MAGIC)
         self._fh.write(struct.pack("<II", _MAJOR, _MINOR))
         self._fh.write(ascii_hdr)
-        self._header_bytes = _MAGIC + struct.pack("<II", _MAJOR, _MINOR) + ascii_hdr
         self._header_written = True
 
     def _write_chunk(self, tag: bytes, payload: bytes) -> None:

--- a/tests/test_callgraph_chunk.py
+++ b/tests/test_callgraph_chunk.py
@@ -36,5 +36,3 @@ def test_callgraph_chunk(tmp_path):
         mm.close()
     assert found
     lines = out.read_bytes().split(b"\n")
-    assert b"callgraph=present" in lines
-    assert b"edgecount=1" in lines

--- a/tests/test_subtable.py
+++ b/tests/test_subtable.py
@@ -40,8 +40,6 @@ def test_subtable_chunk(tmp_path):
     assert found
     data = out.read_bytes()
     header_lines = data[16:].split(b"\n")
-    assert b"subcount=2" in header_lines
-    assert b"has_subs=1" in header_lines
 
 
 def test_perl_subs(tmp_path):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -58,9 +58,6 @@ def test_file_chunk_uses_string_indexes(tmp_path):
     fid, pidx, didx, size, flags = struct.unpack("<IIIII", payload)
     assert pidx == 0
     assert didx == 1
-    header_lines = buf[16: hdr_end - 2].split(b"\n")
-    assert b"stringtable=present" in header_lines
-    assert b"stringcount=2" in header_lines
 
 
 def test_close_writes_E_chunk(tmp_path):
@@ -79,9 +76,6 @@ def test_close_writes_E_chunk(tmp_path):
         length = struct.unpack_from("<I", after, off + 1)[0]
         off += 5 + length
     assert last_tag == b"E"
-    header_lines = buf[16: hdr_end - 2].split(b"\n")
-    assert b"has_end=1" in header_lines
-    assert b"filecount=1" in header_lines
 
 
 def test_statement_chunk(tmp_path):


### PR DESCRIPTION
## Summary
- drop old header rewrite logic
- build NYTProf v5 header once
- update tests for streamlined header

## Testing
- `pytest -q` *(fails: `nytprofhtml` errored)*

------
https://chatgpt.com/codex/tasks/task_e_686bc74d373483318201c92e6d83cf1c