### PR TITLE
Simplify header writing

### DIFF
--- a/src/pynytprof/writer.py
+++ b/src/pynytprof/writer.py
@@ -12,8 +12,7 @@ __all__ = ["Writer"]
 TAG_T = b"T"
 
 _MAGIC = b"NYTPROF\x00"
-_MAJOR = 5
-_MINOR = 0
+_MAJOR, _MINOR = 5, 0
 
 
 class _StringTable:
@@ -227,7 +226,7 @@ class Writer:
             self._fh.close()
         self._fh = None
 
-    def _build_attrs(self) -> bytes:
+    def _write_header(self) -> None:
         lines = [
             f"file={self._path}",
             "version=5",
@@ -236,10 +235,7 @@ class Writer:
         ]
         if self._compressed_used:
             lines.append("compressed=1")
-        return ("\n".join(lines) + "\n\n").encode("ascii")
-
-    def _write_header(self) -> None:
-        ascii_hdr = self._build_attrs()
+        ascii_hdr = ("\n".join(lines) + "\n\n").encode("ascii")
         self._fh.write(_MAGIC)
         self._fh.write(struct.pack("<II", _MAJOR, _MINOR))
         self._fh.write(ascii_hdr)

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -8,28 +8,27 @@ import pytest
 from pynytprof.writer import Writer
 
 
-def test_header_format(tmp_path):
-    p = tmp_path / "nytprof.out"
-    with Writer(str(p)):
+def test_header_format(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with Writer("nytprof.out"):
         pass
+    p = pathlib.Path("nytprof.out")
     hdr = p.read_bytes()[:64]
     assert hdr[:8] == b"NYTPROF\x00"
     assert hdr[8:12] == struct.pack("<I", 5)
     assert hdr[12:16] == struct.pack("<I", 0)
     assert b"\x00" not in hdr[16:32]
-    assert b"file=" in hdr
-    res = subprocess.run(
+    assert hdr[16:21] == b"file="
+    subprocess.run(
         [
             "perl",
             "-MDevel::NYTProf::Data",
             "-e",
             "Devel::NYTProf::Data->new({filename => shift})",
-            str(p),
+            "nytprof.out",
         ],
-        capture_output=True,
+        check=True,
     )
-    if res.returncode != 0:
-        pytest.skip("NYTProf Perl module missing")
 
 
 def test_nytprofhtml(tmp_path):


### PR DESCRIPTION
## Summary
- streamline writer header generation
- refresh header test logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bd99de1588331aedc2ea398682e9d