### PR TITLE
Fix perl profile file loader

### DIFF
--- a/tests/test_header_ascii.py
+++ b/tests/test_header_ascii.py
@@ -20,7 +20,7 @@ def test_ascii_header(tmp_path):
             'perl',
             '-MDevel::NYTProf::Data',
             '-e',
-            'Devel::NYTProf::Data->new(shift)',
+            'Devel::NYTProf::Data->new({filename=>shift})',
             str(out),
         ],
         capture_output=True,

--- a/tests/test_perl_callgraph.py
+++ b/tests/test_perl_callgraph.py
@@ -22,7 +22,7 @@ def test_perl_callgraph(tmp_path):
         "perl",
         "-MDevel::NYTProf::Data",
         "-e",
-        "print Devel::NYTProf::Data->new(shift)->calls",
+        "print Devel::NYTProf::Data->new({filename=>shift})->calls",
         str(out),
     ]
     res = subprocess.run(cmd, capture_output=True, text=True)

--- a/tests/test_perl_lines.py
+++ b/tests/test_perl_lines.py
@@ -27,7 +27,7 @@ def test_perl_lines(tmp_path):
         "perl",
         "-MDevel::NYTProf::Data",
         "-e",
-        "print Devel::NYTProf::Data->new(shift)->lines",
+        "print Devel::NYTProf::Data->new({filename=>shift})->lines",
         str(out_file),
     ]
     res = subprocess.run(cmd, capture_output=True, text=True)

--- a/tests/test_sub_attrs.py
+++ b/tests/test_sub_attrs.py
@@ -61,7 +61,7 @@ def test_perl_sub_attr(tmp_path):
         "perl",
         "-MDevel::NYTProf::Data",
         "-e",
-        "print Devel::NYTProf::Data->new(shift)->subs->[0]->calls",
+        "print Devel::NYTProf::Data->new({filename=>shift})->subs->[0]->calls",
         str(out),
     ]
     res = subprocess.run(cmd, capture_output=True, text=True)

--- a/tests/test_subtable.py
+++ b/tests/test_subtable.py
@@ -52,7 +52,7 @@ def test_perl_subs(tmp_path):
         "perl",
         "-MDevel::NYTProf::Data",
         "-e",
-        "print Devel::NYTProf::Data->new(shift)->subs",
+        "print Devel::NYTProf::Data->new({filename=>shift})->subs",
         str(out),
     ]
     res = subprocess.run(cmd, capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- fix smoke test invocation for Devel::NYTProf::Data

## Testing
- `pytest -q`
- `perl -MDevel::NYTProf::Data -e 'print Devel::NYTProf::Data->new({filename=>shift})->lines' nytprof.out` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_686bed079aac83318b973e575eee9c1d