### PR TITLE
Fix Python writer chunk terminator

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -46,7 +46,8 @@ def _make_ascii_header(start_ns: int) -> bytes:
 
 
 def _chunk(tok: bytes, payload: bytes) -> bytes:
-    return tok + struct.pack("<I", len(payload)) + payload
+    """Return a NYTProf chunk without any extra processing."""
+    return tok[:1] + len(payload).to_bytes(4, "little") + payload
 
 
 class Writer:
@@ -61,11 +62,14 @@ class Writer:
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        self.close()
+        if self._fh:
+            self._fh.write(b"E" + (0).to_bytes(4, "little"))
+            self._fh.close()
+        self._fh = None
 
     def close(self) -> None:
         if self._fh:
-            self._write_chunk(b"E", b"")
+            self._fh.write(b"E" + (0).to_bytes(4, "little"))
             self._fh.close()
         self._fh = None
 

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -1,0 +1,20 @@
+from pathlib import Path, PurePosixPath
+import subprocess, os, sys
+
+
+def test_py_writer_chunks(tmp_path):
+    out = tmp_path/'p.out'
+    subprocess.check_call([
+        sys.executable,
+        '-m','pynytprof.tracer',
+        '-o',str(out),
+        '-e','pass'
+    ], env={**os.environ,'PYNYTPROF_WRITER':'py','PYTHONPATH':str(Path(__file__).resolve().parents[1]/'src')})
+    data = out.read_bytes()
+    hdr_end = 0
+    for _ in range(10):
+        hdr_end = data.index(b'\n', hdr_end) + 1
+    token = data[hdr_end:hdr_end+1]
+    length = int.from_bytes(data[hdr_end+1:hdr_end+5],'little')
+    assert token in b'AF'
+    assert data.endswith(b'E\x00\x00\x00\x00')


### PR DESCRIPTION
## Summary
- ensure `_chunk` only prepends token and payload length
- write the final `E` chunk on writer exit and close
- test that the Python writer emits valid chunks and terminator

## Testing
- `pytest -q tests/test_chunk_py.py`

------
https://chatgpt.com/codex/tasks/task_e_686cf5f690548331960b4f0308a85e1e