### PR TITLE
Update C writer header and add chunk tests

### DIFF
--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -1,0 +1,11 @@
+def test_c_writer_chunks(tmp_path):
+    import subprocess, sys, os
+    out = tmp_path/'c.out'
+    subprocess.check_call([
+        sys.executable,'-m','pynytprof.tracer',
+        '-o',str(out),'-e','pass'
+    ], env={**os.environ,'PYNYTPROF_WRITER':'c'})
+    data = out.read_bytes()
+    assert data.startswith(b'NYTProf 5 0\n')
+    assert data.endswith(b'E\x00\x00\x00\x00')
+


### PR DESCRIPTION
## Summary
- refine `_cwrite` implementation to emit ASCII header
- simplify chunk writing helper and terminator logic
- add regression test for C writer chunk structure

## Testing
- `pytest -q tests/test_chunk_c.py tests/test_header_ascii.py tests/test_header.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfbe4a80c8331912edb43942fe8c4