### PR TITLE
Add F chunk to py writer

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -130,6 +130,12 @@ def write(
         f.write(_make_ascii_header(start_ns))
         a_payload = f"ticks_per_sec={ticks_per_sec}\0start_time={start_ns}\0".encode()
         f.write(_chunk(b"A", a_payload))
+        if not files:
+            script = Path(sys.argv[0]).resolve()
+            st = script.stat()
+            files = [
+                (0, 0x10, st.st_size, int(st.st_mtime), str(script))
+            ]
         f_payload = b"".join(
             struct.pack("<IIII", fid, flags, size, mtime) + p.encode() + b"\0"
             for fid, flags, size, mtime, p in files

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -21,4 +21,9 @@ def test_py_writer_chunks(tmp_path):
     a_pos = data.index(b"A")
     a_len = int.from_bytes(data[a_pos+1:a_pos+5],'little')
     assert data[a_pos+5 + a_len - 1] == 0
+    f_pos = data.index(b'F')
+    f_len = int.from_bytes(data[f_pos+1:f_pos+5],'little')
+    fid   = int.from_bytes(data[f_pos+5:f_pos+9],'little')
+    flags = int.from_bytes(data[f_pos+9:f_pos+13],'little')
+    assert fid == 0 and flags & 0x10
     assert data.endswith(b'E\x00\x00\x00\x00')


### PR DESCRIPTION
## Summary
- add script metadata file chunk in `_pywrite.write`
- check that py writer emits F chunk in chunk tests

## Testing
- `pytest -q tests/test_chunk_py.py::test_py_writer_chunks`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d021124e88331a8ab2c536f25948f