### PR TITLE
Implement inclusive timing in tracer

### DIFF
--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -45,7 +45,7 @@ Mandatory chunks for MVP
 |-------|-------------------------------------------------------------------|--------------------------------------------|
 | `A`   | NUL-joined `key=value` strings                                    | Must repeat `ticks_per_sec` & `start_time` |
 | `F`   | `{u32 fid,u32 flags,u32 size,u32 mtime,zstr path}` × N            | Script = fid 0, set `flags |= 0x10` (HAS_SRC) |
-| `S`   | repeat `{u32 fid,u32 line,u32 calls,u64 inc_ticks,u64 exc_ticks}` | at least one record per executed line |
+| `S`   | repeat `{u32 fid,u32 line,u32 calls,u64 inc_ticks,u64 exc_ticks}` | at least one record per executed line, inc_ticks ≥ 0 (100 ns units) |
 | `C`   | Call-graph edge records (same layout as NYTProf)                  | Optional but improves `nytprofhtml` output |
 | `D`   | Subroutine descriptors                                            | Optional                                   |
 | `E`   | **empty**                                                         | Terminator                                 |

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -2,11 +2,15 @@ import subprocess, sys, os, struct
 from pathlib import Path
 
 
-def test_schunk(tmp_path):
+import pytest
+
+
+@pytest.mark.parametrize("writer", ["py", "c"])
+def test_schunk(tmp_path, writer):
     out = tmp_path / "out"
     env = {
         **os.environ,
-        "PYNYTPROF_WRITER": "py",
+        "PYNYTPROF_WRITER": writer,
         "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
     }
     subprocess.check_call(
@@ -17,3 +21,6 @@ def test_schunk(tmp_path):
     s_pos = data.index(b"S")
     slen = struct.unpack_from("<I", data, s_pos + 1)[0]
     assert slen % 28 == 0 and slen > 0
+    offset = s_pos + 5
+    rec_inc = int.from_bytes(data[offset + 12 : offset + 20], "little")
+    assert rec_inc > 0


### PR DESCRIPTION
## Summary
- track nanosecond timing in `tracer` and include it in S-chunks
- expose `write_chunk` helper in Python writer
- export matching helper from C writer
- validate inclusive timing in S-chunks for both writers
- document `inc_ticks` units

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d106563d48331a15f867272fc4e12