### PR TITLE
Add Python callgraph support

### DIFF
--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -133,19 +133,36 @@ def read(path: str) -> dict:
                 raise ValueError("bad S length")
         elif tok == "D":
             p = 0
-            while p < length:
-                if p + 16 > length:
-                    raise ValueError("bad D record")
-                sid, fid, sl, el = struct.unpack_from("<IIII", payload, p)
-                p += 16
-                end = payload.find(b"\0", p)
-                if end == -1 or end >= length:
-                    raise ValueError("bad D name")
-                name = payload[p:end].decode()
-                p = end + 1
-                result["defs"].append((sid, fid, sl, el, name))
-            if p != length:
-                raise ValueError("bad D length")
+            try:
+                while p < length:
+                    if p + 16 > length:
+                        raise ValueError
+                    sid, fid, sl, el = struct.unpack_from("<IIII", payload, p)
+                    p += 16
+                    end = payload.find(b"\0", p)
+                    if end == -1 or end >= length:
+                        raise ValueError
+                    name = payload[p:end].decode()
+                    p = end + 1
+                    result["defs"].append((sid, fid, sl, el, name))
+                if p != length:
+                    raise ValueError
+            except Exception:
+                result["defs"].clear()
+                p = 0
+                while p < length:
+                    if p + 8 > length:
+                        raise ValueError("bad D record")
+                    sid, flags = struct.unpack_from("<II", payload, p)
+                    p += 8
+                    end = payload.find(b"\0", p)
+                    if end == -1 or end >= length:
+                        raise ValueError("bad D name")
+                    name = payload[p:end].decode()
+                    p = end + 1
+                    result["defs"].append((sid, flags, 0, 0, name))
+                if p != length:
+                    raise ValueError("bad D length")
         elif tok == "C":
             p = 0
             rec_size = 28

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -1,0 +1,25 @@
+import os, sys, subprocess, struct
+from pathlib import Path
+
+
+def test_callgraph_py(tmp_path):
+    script = tmp_path / "t.py"
+    script.write_text(
+        "def foo():\n    bar()\n\ndef bar():\n    pass\n\nfoo()\n"
+    )
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+        "PYNTP_FORCE_PY": "1",
+        "PYNYTPROF_WRITER": "py",
+    }
+    out = tmp_path / "out.nyt"
+    subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), str(script)], env=env)
+    data = out.read_bytes()
+    d_pos = data.index(b"D")
+    d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
+    assert d_len >= struct.calcsize("<II")
+    c_pos = data.index(b"C")
+    c_len = struct.unpack_from("<I", data, c_pos + 1)[0]
+    rec_size = struct.calcsize("<IIIQQ")
+    assert c_len % rec_size == 0 and c_len >= rec_size


### PR DESCRIPTION
## Summary
- record caller->callee pairs in tracer when using Python mode
- output new D and C chunks in `_pywrite` for callgraph
- extend reader to understand simplified D records
- add regression test for Python-only callgraph

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1b2e8ce48331821c3228d3dd5428