### PR TITLE
Fix A-chunk payload

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -69,16 +69,12 @@ class Writer:
     def __enter__(self):
         self._fh = open(self._path, "wb")
         self._write_ascii_header()
-        payload = (
-            f"ticks_per_sec={self.ticks_per_sec}\0" f"start_time={self.start_time}\0"
-        ).encode()
-        pieces = [
-            f"ticks_per_sec={self.ticks_per_sec}".encode(),
-            f"start_time={self.start_time}".encode(),
+        keys = [
+            f"ticks_per_sec={self.ticks_per_sec}",
+            f"start_time={self.start_time}",
         ]
-        assert payload.endswith(b"\0")
-        assert len(payload) == payload.count(b"\0") + sum(len(p) for p in pieces)
-        self._fh.write(_chunk(b"A", payload))
+        payload = b"\0".join(k.encode() for k in keys) + b"\0"
+        self.write_chunk(b"A", payload)
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -196,7 +192,11 @@ def write(
     path = Path(out_path)
     with path.open("wb") as f:
         f.write(_make_ascii_header(start_ns))
-        a_payload = f"ticks_per_sec={ticks_per_sec}\0start_time={start_ns}\0".encode()
+        keys = [
+            f"ticks_per_sec={ticks_per_sec}",
+            f"start_time={start_ns}",
+        ]
+        a_payload = b"\0".join(k.encode() for k in keys) + b"\0"
         f.write(_chunk(b"A", a_payload))
         if not files:
             script = Path(sys.argv[0]).resolve()

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -20,7 +20,9 @@ def test_py_writer_chunks(tmp_path):
     assert b"A" in data
     a_pos = data.index(b"A")
     a_len = int.from_bytes(data[a_pos+1:a_pos+5],'little')
-    assert data[a_pos+5 + a_len - 1] == 0
+    chunk = data[a_pos+5 : a_pos+5+a_len]
+    assert chunk.endswith(b"\0")
+    assert chunk.count(b"\0") == 2
     f_pos = data.index(b'F')
     f_len = int.from_bytes(data[f_pos+1:f_pos+5],'little')
     fid   = int.from_bytes(data[f_pos+5:f_pos+9],'little')


### PR DESCRIPTION
## Summary
- write keys for `A` chunk using a join, ensuring a trailing NUL
- strengthen `test_py_writer_chunks` assertions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2423a7a88331abc181c4786e8481