### PR TITLE
Fix NYTProf header newline

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -39,8 +39,25 @@ def _make_ascii_header(start_ns: int) -> bytes:
         ":ticks_per_sec=10000000",
         f":osname={platform.system().lower()}",
         f":hz={hz}",
+        "!subs=1",
+        "!blocks=0",
+        "!leave=1",
+        "!expand=0",
+        "!trace=0",
+        "!use_db_sub=0",
+        "!compress=0",
+        "!clock=1",
+        "!stmts=1",
+        "!slowops=2",
+        "!findcaller=0",
+        "!forkdepth=-1",
+        "!perldb=0",
+        "!nameevals=1",
+        "!nameanonsubs=1",
+        "!calls=1",
+        "!evals=0",
     ]
-    hdr = ("\n".join(lines) + "\n\n").encode()
+    hdr = ("\n".join(lines) + "\n").encode()
     assert b"\0" not in hdr
     return hdr
 
@@ -167,8 +184,25 @@ class Writer:
             ":ticks_per_sec=10000000",
             f":osname={platform.system().lower()}",
             f":hz={hz}",
+            "!subs=1",
+            "!blocks=0",
+            "!leave=1",
+            "!expand=0",
+            "!trace=0",
+            "!use_db_sub=0",
+            "!compress=0",
+            "!clock=1",
+            "!stmts=1",
+            "!slowops=2",
+            "!findcaller=0",
+            "!forkdepth=-1",
+            "!perldb=0",
+            "!nameevals=1",
+            "!nameanonsubs=1",
+            "!calls=1",
+            "!evals=0",
         ]
-        hdr = ("\n".join(lines) + "\n\n").encode()
+        hdr = ("\n".join(lines) + "\n").encode()
         assert b"\0" not in hdr
         self._fh.write(hdr)
 

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -91,7 +91,24 @@ static void emit_header_ascii(FILE *fp) {
             ":clock_mod=cpu\n"
             ":ticks_per_sec=10000000\n"
             ":osname=%s\n"
-            ":hz=%ld\n",
+            ":hz=%ld\n"
+            "!subs=1\n"
+            "!blocks=0\n"
+            "!leave=1\n"
+            "!expand=0\n"
+            "!trace=0\n"
+            "!use_db_sub=0\n"
+            "!compress=0\n"
+            "!clock=1\n"
+            "!stmts=1\n"
+            "!slowops=2\n"
+            "!findcaller=0\n"
+            "!forkdepth=-1\n"
+            "!perldb=0\n"
+            "!nameevals=1\n"
+            "!nameanonsubs=1\n"
+            "!calls=1\n"
+            "!evals=0\n",
             NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
             PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
 }

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -1,10 +1,15 @@
 def test_c_writer_chunks(tmp_path):
     import subprocess, sys, os
+    from pathlib import Path
 
     out = tmp_path / "c.out"
     subprocess.check_call(
         [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
-        env={**os.environ, "PYNYTPROF_WRITER": "c"},
+        env={
+            **os.environ,
+            "PYNYTPROF_WRITER": "c",
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+        },
     )
     data = out.read_bytes()
     assert data.startswith(b"NYTProf 5 0\n")

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -13,7 +13,8 @@ def test_py_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    first = data.split(b"\n\n", 1)[1]
+    end = data.index(b"\n", data.rfind(b"!evals=0"))
+    first = data[end + 1 :]
     token = first[:1]
     length = int.from_bytes(first[1:5], "little")
     assert token == b"F"

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -24,4 +24,5 @@ def test_ascii_header(tmp_path, writer):
     assert data.startswith(b"NYTProf 5 0\n")
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
-    assert b"A" not in data.split(b"\n\n", 1)[1][:32]  # no A in first chunk
+    end = data.index(b"\n", data.rfind(b"!evals=0"))
+    assert data[end + 1 : end + 2] == b"F"


### PR DESCRIPTION
## Summary
- ensure ASCII header ends with a single newline
- emit default option lines in both writers
- adjust tests for new header structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3028c85c8331b658a36c1bab2810