### PR TITLE
Fix S chunk emission

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -94,13 +94,18 @@ class Writer:
                 import struct
 
                 ns2ticks = lambda ns: ns // 100
-                parts = []
-                for line, calls in self.tracer._line_hits.items():
-                    inc = ns2ticks(self.tracer._line_time_ns[line])
-                    exc = ns2ticks(self.tracer._exc_time_ns.get(line, 0))
-                    parts.append(struct.pack("<IIIQQ", 0, line, calls, inc, exc))
-                if parts:
-                    payload = b"".join(parts)
+                payload = b"".join(
+                    struct.pack(
+                        "<IIIQQ",
+                        0,
+                        line,
+                        calls,
+                        ns2ticks(self.tracer._line_time_ns[line]),
+                        ns2ticks(self.tracer._exc_time_ns.get(line, 0)),
+                    )
+                    for line, calls in self.tracer._line_hits.items()
+                )
+                if payload:
                     self.writer.write_chunk(b"S", payload)
 
                 if self.tracer._calls:
@@ -134,13 +139,18 @@ class Writer:
                 import struct
 
                 ns2ticks = lambda ns: ns // 100
-                parts = []
-                for line, calls in self.tracer._line_hits.items():
-                    inc = ns2ticks(self.tracer._line_time_ns[line])
-                    exc = ns2ticks(self.tracer._exc_time_ns.get(line, 0))
-                    parts.append(struct.pack("<IIIQQ", 0, line, calls, inc, exc))
-                if parts:
-                    payload = b"".join(parts)
+                payload = b"".join(
+                    struct.pack(
+                        "<IIIQQ",
+                        0,
+                        line,
+                        calls,
+                        ns2ticks(self.tracer._line_time_ns[line]),
+                        ns2ticks(self.tracer._exc_time_ns.get(line, 0)),
+                    )
+                    for line, calls in self.tracer._line_hits.items()
+                )
+                if payload:
                     self.writer.write_chunk(b"S", payload)
                 if self.tracer._calls:
                     id_map = {

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -14,8 +14,11 @@ def test_c_writer_chunks(tmp_path):
     data = out.read_bytes()
     assert data.startswith(b"NYTProf 5 0\n")
     assert data.endswith(b"E\x00\x00\x00\x00")
-    f_pos = data.index(b"F")
-    plen = int.from_bytes(data[f_pos + 1 : f_pos + 5], "little")
-    fid = int.from_bytes(data[f_pos + 5 : f_pos + 9], "little")
-    flags = int.from_bytes(data[f_pos + 9 : f_pos + 13], "little")
+    end = data.index(b"\n", data.rfind(b"!evals=0"))
+    chunks = data[end + 1 :]
+    assert chunks[:64].count(b"F") == 1
+    assert chunks[64:256].count(b"S") == 1
+    f_pos = chunks.index(b"F")
+    fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
+    flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")
     assert fid == 0 and (flags & 0x10)

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -14,13 +14,14 @@ def test_py_writer_chunks(tmp_path):
     )
     data = out.read_bytes()
     end = data.index(b"\n", data.rfind(b"!evals=0"))
-    first = data[end + 1 :]
-    token = first[:1]
-    length = int.from_bytes(first[1:5], "little")
+    chunks = data[end + 1 :]
+    assert chunks[:64].count(b"F") == 1
+    assert chunks[64:256].count(b"S") == 1
+    token = chunks[:1]
+    length = int.from_bytes(chunks[1:5], "little")
     assert token == b"F"
-    f_pos = data.index(b"F")
-    f_len = int.from_bytes(data[f_pos + 1 : f_pos + 5], "little")
-    fid = int.from_bytes(data[f_pos + 5 : f_pos + 9], "little")
-    flags = int.from_bytes(data[f_pos + 9 : f_pos + 13], "little")
+    f_pos = chunks.index(b"F")
+    fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
+    flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")
     assert fid == 0 and flags & 0x10
     assert data.endswith(b"E\x00\x00\x00\x00")


### PR DESCRIPTION
## Summary
- build payload for statement chunk once in the Python writer
- validate single `F` and `S` chunk occurrences in chunk tests

## Testing
- `pytest -q tests/test_chunk_py.py tests/test_chunk_c.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3d9eb3cc8331a97bd0fa0b0606aa