### PR TITLE
Fix duplicate F chunk

### DIFF
--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -16,7 +16,7 @@ def test_c_writer_chunks(tmp_path):
     assert data.endswith(b"E\x00\x00\x00\x00")
     end = data.index(b"\n", data.rfind(b"!evals=0"))
     chunks = data[end + 1 :]
-    assert chunks[:64].count(b"F") == 1
+    assert data.count(b"F") == 1
     assert chunks[64:256].count(b"S") == 1
     f_pos = chunks.index(b"F")
     fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")


### PR DESCRIPTION
## Summary
- remove unused emit_F_chunk helper and fallback call from the C writer
- assert only one F chunk is written when using the C writer

## Testing
- `pytest -q tests/test_chunk_c.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4041d980833183bc1de403450b3d