### PR TITLE
Ensure F chunk appears once in chunk tests

### DIFF
--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -16,7 +16,7 @@ def test_c_writer_chunks(tmp_path):
     assert data.endswith(b"E\x00\x00\x00\x00")
     end = data.index(b"\n", data.rfind(b"!evals=0"))
     chunks = data[end + 1 :]
-    assert chunks[:64].count(b"F") == 1
+    assert chunks.count(b"F") == 1
     assert chunks[64:256].count(b"S") == 1
     f_pos = chunks.index(b"F")
     fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -15,7 +15,7 @@ def test_py_writer_chunks(tmp_path):
     data = out.read_bytes()
     end = data.index(b"\n", data.rfind(b"!evals=0"))
     chunks = data[end + 1 :]
-    assert chunks[:64].count(b"F") == 1
+    assert chunks.count(b"F") == 1
     assert chunks[64:256].count(b"S") == 1
     token = chunks[:1]
     length = int.from_bytes(chunks[1:5], "little")


### PR DESCRIPTION
## Summary
- tighten checks for F chunks in chunk tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d55aba9dc833197014cd6bcdf6ba5