### PR TITLE
Respect PYNYTPROF_WRITER default

### DIFF
--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -1,30 +1,36 @@
 from __future__ import annotations
 
+import os
 import warnings
 
 import importlib.metadata
 
-try:
-    from . import _cwrite as _native
-except Exception:
-    _native = None
-
 _version = importlib.metadata.version("pynytprof")
 
-if _native is None or getattr(_native, "__build__", None) != _version:
-    if _native is not None:
-        warnings.warn(
-            "stale _cwrite extension; falling back to pure-Python writer", RuntimeWarning
-        )
-    from . import _pywrite as _fallback
+_pref = os.environ.get("PYNYTPROF_WRITER")
 
-    write = _fallback.write
-    Writer = _fallback.Writer
-else:
-    write = _native.write
-    Writer = getattr(_native, "Writer", None)
+if _pref == "py" or not _pref:
+    from . import _pywrite as _impl
+    write = _impl.write
+    Writer = _impl.Writer
+elif _pref == "c":
+    try:
+        from . import _cwrite as _impl
+    except Exception:
+        _impl = None
+    if _impl is None or getattr(_impl, "__build__", None) != _version:
+        if _impl is not None:
+            warnings.warn(
+                "stale _cwrite extension; falling back to pure-Python writer",
+                RuntimeWarning,
+            )
+        from . import _pywrite as _impl
+    write = _impl.write
+    Writer = getattr(_impl, "Writer", None)
     if Writer is None:
         from . import _pywrite as _fallback
         Writer = _fallback.Writer
+else:
+    raise ImportError(f"unknown writer: {_pref}")
 
 __all__ = ["write", "Writer"]

--- a/tests/test_header_ascii.py
+++ b/tests/test_header_ascii.py
@@ -19,3 +19,18 @@ def test_ascii_header(tmp_path, writer):
     assert data.startswith(b"NYTProf 5 0\n")
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
+
+
+def test_header_banner(tmp_path):
+    """ensure both writer implementations start with an ASCII banner"""
+    out = tmp_path / "hdr.out"
+    for writer in ["py", "c"]:
+        env = {
+            "PYNYTPROF_WRITER": writer,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+        }
+        subprocess.check_call(
+            [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
+            env=env,
+        )
+        assert out.read_bytes().startswith(b"NYTProf 5 0\n")


### PR DESCRIPTION
## Summary
- honour `PYNYTPROF_WRITER` when selecting the write backend
- default to the pure Python writer
- verify both writers start with ASCII header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d58fb01b483319bfa0d29fafc5ff2