### PR TITLE
Emit P chunk and fix tests

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -317,6 +317,16 @@ Writer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     (void)ticks; /* unused */
     basetime = (long)(start_ns / 1000000000ULL);
     emit_header_ascii(self->fp);
+    {
+        uint32_t pid = (uint32_t)getpid();
+        uint32_t ppid = (uint32_t)getppid();
+        double start = (double)time(NULL);
+        uint8_t buf[sizeof(pid) + sizeof(ppid) + sizeof(start)];
+        memcpy(buf, &pid, sizeof(pid));
+        memcpy(buf + 4, &ppid, sizeof(ppid));
+        memcpy(buf + 8, &start, sizeof(start));
+        write_chunk(self->fp, 'P', buf, sizeof(buf));
+    }
     return (PyObject *)self;
 }
 

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -7,7 +7,7 @@ _MAGIC = b"NYTPROF\0"
 _MAJOR = 5
 _MINOR = 0
 _ASCII_PREFIX = b"NYTProf 5 0\n"
-_CHUNK_START = b"ACDFSET"
+_CHUNK_START = b"PACDFSET"
 
 
 def read(path: str) -> dict:
@@ -102,6 +102,11 @@ def read(path: str) -> dict:
                     raise ValueError("bad attr")
                 k, v = item.split(b"=", 1)
                 result["attrs"][k.decode()] = int(v)
+        elif tok == "P":
+            if length != 16:
+                raise ValueError("bad P length")
+            pid, ppid, start = struct.unpack_from("<IId", payload, 0)
+            result["attrs"].update({"pid": pid, "ppid": ppid, "start_time": start})
         elif tok == "F":
             p = 0
             while p < length:

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -121,6 +121,11 @@ def _emit_f(writer: Writer) -> None:
 
 def _write_nytprof(out_path: Path) -> None:
     with Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
+        pid = os.getpid()
+        ppid = os.getppid()
+        start = time.time()
+        payload = struct.pack('<IId', pid, ppid, start)
+        w.write_chunk(b'P', payload)
         _emit_f(w)
 
         if _write.__module__.endswith("_pywrite") and _calls:
@@ -162,6 +167,11 @@ def _write_nytprof(out_path: Path) -> None:
 
 def _write_nytprof_vec(out_path: Path, files, defs, calls, lines) -> None:
     with Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
+        pid = os.getpid()
+        ppid = os.getppid()
+        start = time.time()
+        payload = struct.pack('<IId', pid, ppid, start)
+        w.write_chunk(b'P', payload)
         _emit_f(w)
 
         if defs:
@@ -318,6 +328,11 @@ def profile_command(code: str, out_path: Path | str = "nytprof.out") -> None:
             for line, calls in sorted(_line_hits.items())
         ]
         with Writer(str(out_p), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
+            pid = os.getpid()
+            ppid = os.getppid()
+            start = time.time()
+            payload = struct.pack('<IId', pid, ppid, start)
+            w.write_chunk(b'P', payload)
             _emit_f(w)
             if lines_vec:
                 payload = b"".join(

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -12,11 +12,19 @@ def test_c_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    assert data.count(b"F") == 1
-    assert b"A" not in data
-    assert data.endswith(b"E\x00\x00\x00\x00")
     end = data.index(b"\n", data.rfind(b"!evals=0"))
     chunks = data[end + 1 :]
+    tokens = []
+    off = 0
+    while off < len(chunks):
+        tok = chunks[off:off+1]
+        tokens.append(tok)
+        length = int.from_bytes(chunks[off+1:off+5], "little")
+        off += 5 + length
+    assert tokens.count(b"P") == 1
+    assert tokens.count(b"F") == 1
+    assert b"A" not in tokens
+    assert data.endswith(b"E\x00\x00\x00\x00")
     f_pos = chunks.index(b"F")
     fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
     flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -13,12 +13,19 @@ def test_py_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    assert data.count(b"F") == 1
-    assert b"A" not in data
     end = data.index(b"\n", data.rfind(b"!evals=0"))
     chunks = data[end + 1 :]
-    token = chunks[:1]
-    assert token == b"F"
+    tokens = []
+    off = 0
+    while off < len(chunks):
+        tok = chunks[off:off+1]
+        tokens.append(tok)
+        length = int.from_bytes(chunks[off+1:off+5], "little")
+        off += 5 + length
+    assert tokens.count(b"P") == 1
+    assert tokens.count(b"F") == 1
+    assert b"A" not in tokens
+    assert tokens[0] == b"P"
     f_pos = chunks.index(b"F")
     fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
     flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -25,4 +25,4 @@ def test_ascii_header(tmp_path, writer):
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
     end = data.index(b"\n", data.rfind(b"!evals=0"))
-    assert data[end + 1 : end + 2] == b"F"
+    assert data[end + 1 : end + 2] == b"P"

--- a/tests/test_header_ascii.py
+++ b/tests/test_header_ascii.py
@@ -19,6 +19,8 @@ def test_ascii_header(tmp_path, writer):
     assert data.startswith(b"NYTProf 5 0\n")
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
+    end = data.index(b"\n", data.rfind(b"!evals=0"))
+    assert data[end + 1 : end + 2] == b"P"
 
 
 def test_header_banner(tmp_path):


### PR DESCRIPTION
## Summary
- emit a 'P' chunk before the file chunk in both Python and C writers
- update reader to recognise the new chunk
- adjust tests for the inserted P chunk

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e19f9c1f8833189e3cdf38fadcbcb