### PR TITLE
Fix duplicate P chunk from C writer

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -317,16 +317,6 @@ Writer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     (void)ticks; /* unused */
     basetime = (long)(start_ns / 1000000000ULL);
     emit_header_ascii(self->fp);
-    {
-        uint32_t pid = (uint32_t)getpid();
-        uint32_t ppid = (uint32_t)getppid();
-        double start = (double)time(NULL);
-        uint8_t buf[sizeof(pid) + sizeof(ppid) + sizeof(start)];
-        memcpy(buf, &pid, sizeof(pid));
-        memcpy(buf + 4, &ppid, sizeof(ppid));
-        memcpy(buf + 8, &start, sizeof(start));
-        write_chunk(self->fp, 'P', buf, sizeof(buf));
-    }
     return (PyObject *)self;
 }
 

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -19,10 +19,10 @@ def test_c_writer_chunks(tmp_path):
     while off < len(chunks):
         tok = chunks[off:off+1]
         tokens.append(tok)
-        length = int.from_bytes(chunks[off+1:off+5], "little")
+        length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens.count(b"P") == 1
-    assert tokens.count(b"F") == 1
+    assert tokens.count(b'P') == 1
+    assert tokens.count(b'F') == 1
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
     f_pos = chunks.index(b"F")


### PR DESCRIPTION
## Summary
- avoid emitting P chunk twice when using the C writer
- expect one P chunk in C writer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e294ead9083318831eb397a567ab2