### PR TITLE
Fix missing P chunk emission

### DIFF
--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -119,13 +119,18 @@ def _emit_f(writer: Writer) -> None:
     writer.write_chunk(b"F", payload)
 
 
+def _emit_p(writer: Writer) -> None:
+    import os, time, struct
+    pid = os.getpid()
+    ppid = os.getppid()
+    start = time.time()
+    payload = struct.pack('<IId', pid, ppid, start)
+    writer.write_chunk(b"P", payload)
+
+
 def _write_nytprof(out_path: Path) -> None:
     with Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
-        pid = os.getpid()
-        ppid = os.getppid()
-        start = time.time()
-        payload = struct.pack('<IId', pid, ppid, start)
-        w.write_chunk(b'P', payload)
+        _emit_p(w)
         _emit_f(w)
 
         if _write.__module__.endswith("_pywrite") and _calls:
@@ -167,11 +172,7 @@ def _write_nytprof(out_path: Path) -> None:
 
 def _write_nytprof_vec(out_path: Path, files, defs, calls, lines) -> None:
     with Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
-        pid = os.getpid()
-        ppid = os.getppid()
-        start = time.time()
-        payload = struct.pack('<IId', pid, ppid, start)
-        w.write_chunk(b'P', payload)
+        _emit_p(w)
         _emit_f(w)
 
         if defs:
@@ -328,11 +329,7 @@ def profile_command(code: str, out_path: Path | str = "nytprof.out") -> None:
             for line, calls in sorted(_line_hits.items())
         ]
         with Writer(str(out_p), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
-            pid = os.getpid()
-            ppid = os.getppid()
-            start = time.time()
-            payload = struct.pack('<IId', pid, ppid, start)
-            w.write_chunk(b'P', payload)
+            _emit_p(w)
             _emit_f(w)
             if lines_vec:
                 payload = b"".join(

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -22,6 +22,7 @@ def test_c_writer_chunks(tmp_path):
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
     assert tokens.count(b'P') == 1
+    assert tokens[0] == b'P'
     assert tokens.count(b'F') == 1
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")


### PR DESCRIPTION
## Summary
- add `_emit_p` helper and call it before writing file table
- check that `P` token is first in C writer test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2f8682788331ac8bca60cffc1547