### PR TITLE
Add statement chunk emission

### DIFF
--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -21,9 +21,7 @@ def test_c_writer_chunks(tmp_path):
         tokens.append(tok)
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens.count(b'P') == 1
-    assert tokens[0] == b'P'
-    assert tokens.count(b'F') == 1
+    assert tokens == [b'P', b'F', b'S', b'E']
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
     f_pos = chunks.index(b"F")

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -22,10 +22,8 @@ def test_py_writer_chunks(tmp_path):
         tokens.append(tok)
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length
-    assert tokens.count(b"P") == 1
-    assert tokens.count(b"F") == 1
+    assert tokens == [b"P", b"F", b"S", b"E"]
     assert b"A" not in tokens
-    assert tokens[0] == b"P"
     f_pos = chunks.index(b"F")
     fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
     flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")


### PR DESCRIPTION
## Summary
- include executed line data in tracer output
- expect a `S` chunk in chunk tests
- check single S chunk length in S-chunk test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e34fad3c48331aedaf777363d2036