### PR TITLE
Fix S-chunk and E-chunk emission

### DIFF
--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -30,7 +30,7 @@ def test_schunk(tmp_path, writer):
         if tok == b"S":
             s_off = off
         off += 5 + length
-    assert tokens.count(b"S") == 1
+    assert tokens == [b"P", b"F", b"S", b"E"]
     assert s_off is not None
     slen = int.from_bytes(chunks[s_off + 1 : s_off + 5], "little")
     assert slen % 28 == 0 and slen > 0


### PR DESCRIPTION
## Summary
- ensure Python tracer writes callgraph only when forced
- always emit S-chunk and rely on writer for E-chunk
- account for time spent inside callees when computing inclusive ticks
- update S-chunk test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4380c2608331994f1a5786e02d1e