### PR TITLE
Implement statement chunk emission

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document describes how **Pynytprof** works and how its modules fit together
 
 ---
 
-## Component Map
+## Component map
 
 | Module                        | Responsibility                                                |
 |--------------------------------|--------------------------------------------------------------|
@@ -20,7 +20,7 @@ This document describes how **Pynytprof** works and how its modules fit together
 
 ---
 
-## Runtime Flow
+## Runtime flow
 
 1. **Initialization**  
    `profile_script()` or `Tracer()` decides whether to use:


### PR DESCRIPTION
## Summary
- output S chunk with per-line stats in `tracer.py`
- ensure headings in Architecture document match tests
- fix `profile_command` so expressions are traced

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m pynytprof.tracer -o nytprof.out tests/example_script.py`
- `xxd -s 390 -l 120 nytprof.out`
- `nytprofhtml -f nytprof.out` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_686e6cb4cb28833189d0d7a4d75ecbe0