### PR TITLE
Fix C writer header newline and clean up tests

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -94,6 +94,7 @@ static void emit_header_ascii(FILE *fp) {
             "!evals=0\n",
             NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
             PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
+    fputc('\n', fp);
 }
 
 static PyObject *pynytprof_write(PyObject *self, PyObject *args) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+def get_chunk_start(data):
+    cutoff = data.index(b"\n\n") + 2
+    return cutoff

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -1,14 +1,14 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
@@ -8,7 +9,7 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -1,14 +1,14 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_c_writer_emits_D_third(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_py_writer_emits_D_third(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
@@ -8,7 +9,7 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -1,14 +1,14 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_c_writer_emits_E_last(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_py_writer_emits_E_last(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
@@ -8,7 +9,7 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_F_first_c.py
+++ b/tests/test_chunk_F_first_c.py
@@ -1,12 +1,12 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_c_writer_emits_F_first(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     assert data[cutoff:cutoff+1] == b'F'

--- a/tests/test_chunk_F_first_py.py
+++ b/tests/test_chunk_F_first_py.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_py_writer_emits_F_first(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
@@ -8,5 +9,5 @@ def test_py_writer_emits_F_first(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     assert data[cutoff:cutoff+1] == b'F'

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -1,14 +1,14 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_c_writer_emits_S_second(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 def test_py_writer_emits_S_second(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
@@ -8,7 +9,7 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -1,6 +1,7 @@
 def test_c_writer_chunks(tmp_path):
     import subprocess, sys, os
     from pathlib import Path
+    from tests.conftest import get_chunk_start
 
     out = tmp_path / "c.out"
     subprocess.check_call(
@@ -12,7 +13,7 @@ def test_c_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    end = data.index(b"\n\n") + 2
+    end = get_chunk_start(data)
     chunks = data[end:]
     tokens = []
     off = 0

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -1,12 +1,13 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 SCRIPT = 'tests/cg_example.py'
 
 
 def _tokens(out):
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     toks = []
     off = cutoff
     while off < len(data):
@@ -28,7 +29,6 @@ def test_full_sequence_py(tmp_path, monkeypatch):
 def test_full_sequence_c(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
-    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), SCRIPT])
     assert _tokens(out) == b'FSDCE'

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 import pytest
 
@@ -24,5 +25,5 @@ def test_ascii_header(tmp_path, writer):
     assert data.startswith(b"NYTProf 5 0\n")
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
-    cutoff = data.index(b"\n\n") + 2
+    cutoff = get_chunk_start(data)
     assert data[cutoff:cutoff + 1] == b"F"

--- a/tests/test_header_ascii.py
+++ b/tests/test_header_ascii.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 import pytest
+from tests.conftest import get_chunk_start
 
 
 @pytest.mark.parametrize("writer", ["py", "c"])
@@ -19,7 +20,7 @@ def test_ascii_header(tmp_path, writer):
     assert data.startswith(b"NYTProf 5 0\n")
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
-    cutoff = data.index(b"\n\n") + 2
+    cutoff = get_chunk_start(data)
     assert data[cutoff:cutoff + 1] == b"F"
 
 

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess, os, sys
+from tests.conftest import get_chunk_start
 
 def test_first_token_is_F(tmp_path):
     out = tmp_path / 'nytprof.out'
@@ -15,6 +16,6 @@ def test_first_token_is_F(tmp_path):
         'tests/example_script.py'
     ], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b'\n\n') + 2
+    cutoff = get_chunk_start(data)
     assert data[cutoff] == 0x46  # 'F'
     assert data[cutoff - 1] == 0x0A  # banner ends with a blank line


### PR DESCRIPTION
## Summary
- ensure C writer ASCII header ends with a blank line
- add `get_chunk_start` helper for locating payload start
- use helper across chunk-order tests
- remove `PYNTP_FORCE_PY` from C writer tests

## Testing
- `pytest -q` *(fails: AssertionError in C-writer tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ef7a6cc188331a7a7d30288fa4cd7