### PR TITLE
Ensure single F chunk in py writer

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -83,12 +83,18 @@ class Writer:
         self.tracer = tracer
         self.writer = self
         self._line_hits: dict[tuple[int, int], tuple[int, int, int]] = {}
+        # guard against accidental duplicate file table emission
+        self._wrote_f = False
 
     def record_line(self, fid: int, line: int, calls: int, inc: int, exc: int) -> None:
         self._line_hits[(fid, line)] = (calls, inc, exc)
 
     # expose the same api the C writer will have
     def write_chunk(self, token: bytes, payload: bytes):
+        if token == b"F":
+            if self._wrote_f:
+                return
+            self._wrote_f = True
         self._write_chunk(token, payload)
 
     def __enter__(self):

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -1,0 +1,21 @@
+import os, subprocess, sys
+from pathlib import Path
+from tests.conftest import get_chunk_start
+
+
+def test_only_one_F_chunk(tmp_path, monkeypatch):
+    out = tmp_path / 'nytprof.out'
+    monkeypatch.setenv('PYNYTPROF_WRITER', 'py')
+    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
+    monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
+    subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'])
+    data = out.read_bytes()
+    cutoff = get_chunk_start(data)
+    tags = []
+    off = cutoff
+    while off < len(data):
+        tags.append(data[off:off+1])
+        length = int.from_bytes(data[off+1:off+5], 'little')
+        off += 5 + length
+    f_count = sum(1 for t in tags if t == b'F')
+    assert f_count == 1, f'Expected exactly one F chunk, found {f_count}'


### PR DESCRIPTION
## Summary
- prevent duplicate `F` chunk emission in the pure-Python writer
- add regression test confirming only one `F` chunk exists

## Testing
- `pytest -q tests/test_single_F_chunk_py.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f033021f48331814c6fd7b128cf0e