### PR TITLE
Remove newline tag emissions

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -83,18 +83,12 @@ class Writer:
         self.tracer = tracer
         self.writer = self
         self._line_hits: dict[tuple[int, int], tuple[int, int, int]] = {}
-        # guard against accidental duplicate file table emission
-        self._wrote_f = False
 
     def record_line(self, fid: int, line: int, calls: int, inc: int, exc: int) -> None:
         self._line_hits[(fid, line)] = (calls, inc, exc)
 
     # expose the same api the C writer will have
     def write_chunk(self, token: bytes, payload: bytes):
-        if token == b"F":
-            if self._wrote_f:
-                return
-            self._wrote_f = True
         self._write_chunk(token, payload)
 
     def __enter__(self):

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -1,0 +1,30 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def _chunk_tags(data):
+    cutoff = data.index(b"\n\n") + 2
+    tags = []
+    off = cutoff
+    while off < len(data):
+        tag = data[off:off+1]
+        tags.append(tag)
+        length = int.from_bytes(data[off+1:off+5], "little")
+        off += 5 + length
+    return tags
+
+
+def test_no_spurious_tags(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
+        env=env,
+    )
+    data = out.read_bytes()
+    tags = _chunk_tags(data)
+    assert tags == [b"F", b"S", b"D", b"C", b"E"], tags


### PR DESCRIPTION
## Summary
- add regression test ensuring no spurious chunk tags are emitted
- simplify `_pywrite.Writer` by removing obsolete `_wrote_f` flag

## Testing
- `pytest -q tests/test_no_spurious_tags_py.py`

------
https://chatgpt.com/codex/tasks/task_e_686f061d4e6083318c9954441eb9322d