### PR TITLE
Fix newline termination in banner

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -57,7 +57,7 @@ def _make_ascii_header(start_ns: int) -> bytes:
         "!calls=1",
         "!evals=0",
     ]
-    hdr = b"\n".join(l.encode() for l in lines) + b"\n\n"
+    hdr = ("\n".join(lines) + "\n\n").encode()
     assert b"\0" not in hdr
     return hdr
 
@@ -185,7 +185,7 @@ class Writer:
             "!calls=1",
             "!evals=0",
         ]
-        hdr = b"\n".join(l.encode() for l in lines) + b"\n\n"
+        hdr = ("\n".join(lines) + "\n\n").encode()
         assert b"\0" not in hdr
         self._fh.write(hdr)
 

--- a/tests/test_banner_exact_termination.py
+++ b/tests/test_banner_exact_termination.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_banner_ends_with_two_newlines(tmp_path):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
+        env=env,
+    )
+    data = out.read_bytes()
+    idx = data.find(b"\n\n")
+    assert idx != -1, "Did not find \\n\\n"
+    next_bytes = data[idx:idx+3]
+    assert next_bytes == b"\n\nF", f"Expected exactly '\\n\\nF', got {next_bytes}"


### PR DESCRIPTION
## Summary
- ensure ASCII header ends with exactly two newlines
- add regression test verifying banner termination

## Testing
- `pytest -q tests/test_banner_exact_termination.py`

------
https://chatgpt.com/codex/tasks/task_e_686f09afbcfc8331a72e83ac07e721bf