### PR TITLE
Refactor py writer chunk emission

### DIFF
--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -184,9 +184,8 @@ def _write_nytprof(out_path: Path) -> None:
 
         w.write_chunk(b"E", b"")
     finally:
-        if getattr(w, "_fh", None):
-            w._fh.close()
-            w._fh = None
+        if getattr(w, "close", None):
+            w.close()
         if os.environ.get("PYNYTPROF_DEBUG"):
             data = Path(out_path).read_bytes()
             cutoff = data.index(b"\n\n") + 2

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -1,0 +1,24 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_only_five_top_level_chunks(tmp_path, monkeypatch):
+    out = tmp_path/'nytprof.out'
+    monkeypatch.setenv('PYNYTPROF_WRITER','py')
+    monkeypatch.setenv('PYNTP_FORCE_PY', '1')
+    monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
+    subprocess.check_call([
+        sys.executable,
+        '-m','pynytprof.tracer',
+        '-o', str(out),
+        'tests/example_script.py'
+    ])
+    data = out.read_bytes()
+    cutoff = data.index(b'\n\n')+2
+    tags = []
+    off = cutoff
+    while off < len(data):
+        tags.append(data[off:off+1])
+        length = int.from_bytes(data[off+1:off+5],'little')
+        off += 5 + length
+    assert tags == [b'F',b'S',b'D',b'C',b'E'], f"Got {tags!r}"


### PR DESCRIPTION
## Summary
- add regression test for python writer chunk count
- accumulate writer payloads
- write all chunks in one pass on close
- call writer.close in tracer

## Testing
- `pytest -q tests/test_chunk_count_py.py`
- `PYTHONPATH=$(pwd)/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f524f0bc88331bd3970dc5cf06cdf