### PR TITLE
Fix active writer buffering

### DIFF
--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -39,8 +39,7 @@ class Writer:
         }
 
     def _buffer_chunk(self, tag: bytes, payload: bytes) -> None:
-        if payload:
-            self._buf[tag].extend(payload)
+        self._buf[tag].extend(payload)
 
     def record_line(self, fid: int, line: int, calls: int, inc: int, exc: int) -> None:
         self._line_hits[(fid, line)] = (calls, inc, exc)


### PR DESCRIPTION
## Summary
- ensure the pure Python writer buffers even empty payloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fba1f3aac83318001bb373871b19c