### PR TITLE
Fix duplicate E chunk in C writer

### DIFF
--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -181,8 +181,6 @@ def _write_nytprof(out_path: Path) -> None:
             w.write_chunk(b"D", b"")
         if not emitted_c:
             w.write_chunk(b"C", b"")
-
-        w.write_chunk(b"E", b"")
     finally:
         if getattr(w, "close", None):
             w.close()
@@ -216,8 +214,6 @@ def _write_nytprof_vec(out_path: Path, files, defs, calls, lines) -> None:
                 for fid, line, sid, inc, exc in calls
             )
             w.write_chunk(b"C", c_payload)
-        # Always terminate with an empty E-chunk
-        w.write_chunk(b"E", b"")
     if os.environ.get("PYNYTPROF_DEBUG"):
         data = Path(out_path).read_bytes()
         cutoff = data.index(b"\n\n") + 2


### PR DESCRIPTION
## Summary
- avoid writing an extra E chunk when using the C writer
- `_write_nytprof` and `_write_nytprof_vec` now rely on `Writer.close()` for termination

## Testing
- `PYNYTPROF_WRITER=py pytest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe401e3488331ae2d3684c99a97f0