### PR TITLE
Fix empty D chunk with Python tracer

### DIFF
--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -153,7 +153,7 @@ def _write_nytprof(out_path: Path) -> None:
 
         emitted_d = False
         emitted_c = False
-        if _force_py and _write.__module__.endswith("_pywrite") and _calls:
+        if _write.__module__.endswith("_pywrite") and _calls:
             id_map = {}
             for name in sorted({n for pair in _calls for n in pair}):
                 sid = len(id_map)


### PR DESCRIPTION
## Summary
- ensure Python tracer emits non-empty `D` chunk when using `py` writer

## Testing
- `pytest tests/test_S_and_D_non_empty.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fe84784748331b3fa16a3f7a0993f