### PR TITLE
Add stricter spurious tag test

### DIFF
--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -1,30 +1,34 @@
-import os, subprocess, sys
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 
-def _chunk_tags(data):
-    cutoff = data.index(b"\n\n") + 2
-    tags = []
-    off = cutoff
-    while off < len(data):
-        tag = data[off:off+1]
-        tags.append(tag)
-        length = int.from_bytes(data[off+1:off+5], "little")
-        off += 5 + length
-    return tags
-
-
-def test_no_spurious_tags(tmp_path):
+def test_no_spurious_tags(tmp_path, monkeypatch):
     out = tmp_path / "nytprof.out"
-    env = {
-        **os.environ,
-        "PYNYTPROF_WRITER": "py",
-        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
-    }
+    monkeypatch.setenv("PYNYTPROF_WRITER", "py")
+    monkeypatch.setenv(
+        "PYTHONPATH", str(Path(__file__).resolve().parents[1] / "src")
+    )
     subprocess.check_call(
-        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
-        env=env,
+        [
+            sys.executable,
+            "-m",
+            "pynytprof.tracer",
+            "-o",
+            str(out),
+            "tests/example_script.py",
+        ],
+        env=os.environ,
     )
     data = out.read_bytes()
-    tags = _chunk_tags(data)
-    assert tags == [b"F", b"S", b"D", b"C", b"E"], tags
+    idx = data.index(b"\n\n") + 2
+    tags = []
+    off = idx
+    while off < len(data):
+        tag = data[off : off + 1]
+        tags.append(tag)
+        length = int.from_bytes(data[off + 1 : off + 5], "little")
+        off += 5 + length
+
+    assert tags == [b"F", b"S", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"


### PR DESCRIPTION
## Summary
- enhance `test_no_spurious_tags_py.py` so it runs a real script and validates
  the binary chunk stream for any stray tags

## Testing
- `pytest -q tests/test_no_spurious_tags_py.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686feb8b6e5c83319aef26717e36c1e1