### PR TITLE
Add PYNYTPROF_DEBUG verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ an error status if the file is corrupted.
 pynytprof verify nytprof.out
 ```
 
+## Debugging
+Set `PYNYTPROF_DEBUG=1` to print the chosen writer class and a summary of each
+chunk written. Debug information is emitted to stderr.
+
 ## Flamegraph output
 Use the `speedscope` command to generate JSON for the Speedscope viewer.
 

--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -96,6 +96,12 @@ class Writer:
     # expose the same api the C writer will have
     def write_chunk(self, token: bytes, payload: bytes):
         tag = token[:1]
+        if os.getenv("PYNYTPROF_DEBUG"):
+            import sys
+            print(
+                f"EVENT CHUNK: tag={tag.decode()} len={len(payload)}",
+                file=sys.stderr,
+            )
         if tag in self._buf:
             self._buf[tag].extend(payload)
         elif tag == b"E":
@@ -158,6 +164,12 @@ class Writer:
             s_payload = b"".join(recs)
             if s_payload:
                 self._buf[b"S"].extend(s_payload)
+            if os.getenv("PYNYTPROF_DEBUG"):
+                import sys
+                summary = ", ".join(
+                    f"{t.decode()}={len(buf)}" for t, buf in self._buf.items()
+                )
+                print(f"FINAL CHUNKS: {summary}", file=sys.stderr)
             self._dump_chunks()
             self._fh.close()
         self._fh = None

--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -39,6 +39,12 @@ class Writer:
         }
 
     def _buffer_chunk(self, tag: bytes, payload: bytes) -> None:
+        if os.getenv("PYNYTPROF_DEBUG"):
+            import sys
+            print(
+                f"EVENT CHUNK: tag={tag.decode()} len={len(payload)}",
+                file=sys.stderr,
+            )
         if payload:
             self._buf[tag].extend(payload)
 
@@ -85,6 +91,13 @@ class Writer:
                 recs.append(struct.pack("<IIIQQ", fid, line, calls, inc, exc))
             if recs:
                 self._buffer_chunk(b"S", b"".join(recs))
+
+        if os.getenv("PYNYTPROF_DEBUG"):
+            import sys
+            summary = ", ".join(
+                f"{t.decode()}={len(buf)}" for t, buf in self._buf.items()
+            )
+            print(f"FINAL CHUNKS: {summary}", file=sys.stderr)
 
         hdr = _make_ascii_header(self._start_ns)
         self._fh.write(hdr)

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -126,6 +126,11 @@ def _emit_p(writer: Writer) -> None:
 
 def _write_nytprof(out_path: Path) -> None:
     w = Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC)
+    if os.environ.get("PYNYTPROF_DEBUG"):
+        print(
+            f"USING WRITER: {w.__class__.__module__}.{w.__class__.__name__}",
+            file=sys.stderr,
+        )
     w.__enter__()
     try:
         _emit_f(w)
@@ -181,14 +186,15 @@ def _write_nytprof(out_path: Path) -> None:
     finally:
         if getattr(w, "close", None):
             w.close()
-        if os.environ.get("PYNYTPROF_DEBUG"):
-            data = Path(out_path).read_bytes()
-            cutoff = data.index(b"\n\n") + 2
-            print(data[cutoff:cutoff + 5])
 
 
 def _write_nytprof_vec(out_path: Path, files, defs, calls, lines) -> None:
     with Writer(str(out_path), start_ns=_start_ns, ticks_per_sec=TICKS_PER_SEC) as w:
+        if os.environ.get("PYNYTPROF_DEBUG"):
+            print(
+                f"USING WRITER: {w.__class__.__module__}.{w.__class__.__name__}",
+                file=sys.stderr,
+            )
         _emit_f(w)
 
         if lines:
@@ -211,10 +217,6 @@ def _write_nytprof_vec(out_path: Path, files, defs, calls, lines) -> None:
                 for fid, line, sid, inc, exc in calls
             )
             w.write_chunk(b"C", c_payload)
-    if os.environ.get("PYNYTPROF_DEBUG"):
-        data = Path(out_path).read_bytes()
-        cutoff = data.index(b"\n\n") + 2
-        print(data[cutoff:cutoff + 5])
 
 def _trace(frame: FrameType, event: str, arg: Any) -> Any:
     global _last_ts

--- a/tests/test_debug_chunk_summary.py
+++ b/tests/test_debug_chunk_summary.py
@@ -1,0 +1,18 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_debug_chunk_summary(tmp_path):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYNTP_FORCE_PY': '1',
+        'PYNYTPROF_DEBUG': '1',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
+        env=env, stderr=subprocess.PIPE, text=True
+    )
+    assert 'FINAL CHUNKS:' in proc.stderr

--- a/tests/test_debug_flag_shows_writer.py
+++ b/tests/test_debug_flag_shows_writer.py
@@ -1,0 +1,18 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_debug_flag_shows_writer(tmp_path, monkeypatch):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYNTP_FORCE_PY': '1',
+        'PYNYTPROF_DEBUG': '1',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
+        env=env, stderr=subprocess.PIPE, text=True
+    )
+    assert 'USING WRITER:' in proc.stderr

--- a/tests/test_debug_per_event_logs.py
+++ b/tests/test_debug_per_event_logs.py
@@ -1,0 +1,18 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_debug_per_event_logs(tmp_path, monkeypatch):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYNTP_FORCE_PY': '1',
+        'PYNYTPROF_DEBUG': '1',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
+        env=env, stderr=subprocess.PIPE, text=True
+    )
+    assert 'EVENT CHUNK:' in proc.stderr


### PR DESCRIPTION
## Summary
- implement optional debug logging triggered by `PYNYTPROF_DEBUG=1`
- log writer class selection, every chunk buffered, and final chunk sizes
- add tests covering debug output
- document debug mode in README

## Testing
- `pytest -q tests/test_debug_flag_shows_writer.py tests/test_debug_per_event_logs.py tests/test_debug_chunk_summary.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ffb75290c8331b71c7fb45cf10d69