### PR TITLE
Add verbose debug instrumentation to writer

### DIFF
--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 def test_S_and_D_non_empty(tmp_path, monkeypatch):
     out = tmp_path/'nytprof.out'
-    env = {**os.environ, "PYNYTPROF_WRITER": "py"}
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
     subprocess.check_call(
         [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "tests/example_script.py"],
         env=env,

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -1,7 +1,12 @@
 def test_c_writer_emits_C_chunk(tmp_path):
     import subprocess, sys, os
+    from pathlib import Path
     out = tmp_path / "nytprof.out"
-    env = {**os.environ, "PYNYTPROF_WRITER": "c"}
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "c",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
     cutoff = data.index(b"\n\n") + 2

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -1,7 +1,12 @@
 def test_c_writer_emits_D_chunk(tmp_path):
     import subprocess, sys, os
+    from pathlib import Path
     out = tmp_path / "nytprof.out"
-    env = {**os.environ, "PYNYTPROF_WRITER": "c"}
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "c",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
     cutoff = data.index(b"\n\n") + 2

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -1,7 +1,12 @@
 def test_c_writer_chunk_sequence(tmp_path):
     import subprocess, sys, os
+    from pathlib import Path
     out = tmp_path / "nytprof.out"
-    env = {**os.environ, "PYNYTPROF_WRITER": "c"}
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "c",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
     cutoff = data.index(b"\n\n") + 2

--- a/tests/test_debug_per_event_logs.py
+++ b/tests/test_debug_per_event_logs.py
@@ -15,4 +15,4 @@ def test_debug_per_event_logs(tmp_path, monkeypatch):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'EVENT CHUNK:' in proc.stderr
+    assert 'DEBUG: buffering chunk' in proc.stderr


### PR DESCRIPTION
## Summary
- add in-depth debug logging in `_pywrite` writer
- propagate debug logging to `_writer` and minimal `writer` implementations
- ensure subprocess tests set `PYTHONPATH`

## Testing
- `pytest -n auto`
- `PYNYTPROF_DEBUG=1 PYNYTPROF_WRITER=py PYTHONPATH=src python -m pynytprof.tracer tests/example_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68701745363083319c3707e73dac1b51