### PR TITLE
Add newline-free payload tests

### DIFF
--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -1,0 +1,29 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_D_payload_free_of_newlines(tmp_path):
+    out = tmp_path/'nytprof.out'
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER":"py",
+        "PYNYTPROF_DEBUG":"1",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]/"src"),
+    }
+    subprocess.check_call(
+        [sys.executable,"-m","pynytprof.tracer","-o",str(out),"-e","pass"],
+        env=env
+    )
+    data = out.read_bytes()
+    idx = data.index(b'\n\n')+2
+    # skip F
+    flen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5+flen
+    # skip S
+    slen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5 + slen
+    # expect D
+    assert data[idx:idx+1]==b'D'
+    dlen = int.from_bytes(data[idx+1:idx+5],'little')
+    dpayload = data[idx+5:idx+5+dlen]
+    assert b'\n' not in dpayload, "D payload contains newline"

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -1,0 +1,26 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_S_payload_free_of_newlines(tmp_path):
+    out = tmp_path/'nytprof.out'
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER":"py",
+        "PYNYTPROF_DEBUG":"1",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]/"src"),
+    }
+    subprocess.check_call(
+        [sys.executable,"-m","pynytprof.tracer","-o",str(out),"-e","pass"],
+        env=env
+    )
+    data = out.read_bytes()
+    idx = data.index(b'\n\n')+2
+    # skip F
+    flen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5+flen
+    # expect S tag
+    assert data[idx:idx+1]==b'S'
+    slen = int.from_bytes(data[idx+1:idx+5],'little')
+    spayload = data[idx+5:idx+5+slen]
+    assert b'\n' not in spayload, "S payload contains newline"


### PR DESCRIPTION
## Summary
- ensure S and D chunk payloads contain no newline bytes
- run test suite with parallel workers

## Testing
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68701d667e2883318e2768bf78e2d2db