### PR TITLE
Use binary data tokens for D chunk

### DIFF
--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -1,12 +1,13 @@
-import os, sys, subprocess, struct
+import os
+import sys
+import subprocess
+import struct
 from pathlib import Path
 
 
 def test_callgraph_py(tmp_path):
     script = tmp_path / "t.py"
-    script.write_text(
-        "def foo():\n    bar()\n\ndef bar():\n    pass\n\nfoo()\n"
-    )
+    script.write_text("def foo():\n    bar()\n\ndef bar():\n    pass\n\nfoo()\n")
     env = {
         **os.environ,
         "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
@@ -14,11 +15,13 @@ def test_callgraph_py(tmp_path):
         "PYNYTPROF_WRITER": "py",
     }
     out = tmp_path / "out.nyt"
-    subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), str(script)], env=env)
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), str(script)], env=env
+    )
     data = out.read_bytes()
     d_pos = data.index(b"D")
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
-    assert d_len >= struct.calcsize("<II")
+    assert d_len >= 1
     c_pos = data.index(b"C")
     c_len = struct.unpack_from("<I", data, c_pos + 1)[0]
     rec_size = struct.calcsize("<IIIQQ")


### PR DESCRIPTION
## Summary
- add regression test checking for binary D payload
- support collecting statement token records in `_pywrite`
- skip callgraph defs when writing with tracer
- parse binary line records in reader
- update callgraph test expectation

## Testing
- `ruff check tests/test_callgraph_pyonly.py tests/test_dchunk_binary.py src/pynytprof/_pywrite.py src/pynytprof/tracer.py src/pynytprof/reader.py --no-cache --isolated`
- `black tests/test_callgraph_pyonly.py src/pynytprof/tracer.py tests/test_dchunk_binary.py src/pynytprof/_pywrite.py src/pynytprof/reader.py --config /tmp/pyproject.toml`
- `pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_6870208b065c8331848c587fcd356c61