### PR TITLE
Fix duplicate D chunk buffering

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -139,6 +139,10 @@ class Writer:
     def write_chunk(self, token: bytes, payload: bytes):
         tag = token[:1]
         if tag in self._buf:
+            if tag == b"D" and not payload:
+                # tracer may emit an empty D just to signal its presence.
+                # Ignore it to avoid buffering the chunk twice.
+                return
             self._buffer_chunk(tag, payload)
         elif tag == b"E":
             pass  # handled on close

--- a/tests/test_chunk_uniqueness.py
+++ b/tests/test_chunk_uniqueness.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import subprocess
+import re
+from pathlib import Path
+import pytest
+
+
+def test_chunk_uniqueness(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYNTP_FORCE_PY": "1",
+        "PYNYTPROF_DEBUG": "1",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    proc = subprocess.run(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "tests/example_script.py"],
+        env=env,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    pattern = re.compile(r"^DEBUG: buffering chunk tag=(\w) offset=0x([0-9a-f]+)")
+    seen = set()
+    duplicates = []
+    for line in proc.stderr.splitlines():
+        m = pattern.search(line)
+        if m:
+            key = (m.group(1), int(m.group(2), 16))
+            if key in seen:
+                duplicates.append(key)
+            seen.add(key)
+    assert not duplicates, f"duplicate chunks: {duplicates}"


### PR DESCRIPTION
## Summary
- add a regression test to ensure no chunk tag is buffered at the same offset twice
- skip buffering empty `D` chunks in Python writer

## Testing
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_6870403c71708331b271686e9a2f5ebc