### PR TITLE
Fix Python writer header case

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -24,7 +24,7 @@ NYTPROF_MINOR = int(_minor_match.group(1)) if _minor_match else 0
 
 
 def _make_ascii_header(start_ns: int) -> bytes:
-    now = format_datetime(datetime.datetime.now(datetime.timezone.utc))
+    now = format_datetime(datetime.datetime.now(datetime.timezone.utc)).lower()
     try:
         hz = os.sysconf("SC_CLK_TCK")  # type: ignore[arg-type]
     except (AttributeError, ValueError, OSError):


### PR DESCRIPTION
## Summary
- normalize the timestamp used in `_make_ascii_header` to lowercase
- this prevents stray capital letters in the header, allowing tests to locate
  chunk markers reliably

## Testing
- `pytest -n auto -q`
- `PYNYTPROF_WRITER=py pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_68736fe2a60483318256bebee8bb8e7e