### PR TITLE
Remove F-chunk expectations

### DIFF
--- a/tests/test_banner_exact_termination.py
+++ b/tests/test_banner_exact_termination.py
@@ -19,4 +19,4 @@ def test_banner_ends_with_two_newlines(tmp_path):
     idx = data.find(b"\n\n")
     assert idx != -1, "Did not find \\n\\n"
     next_bytes = data[idx:idx+3]
-    assert next_bytes == b"\n\nF", f"Expected exactly '\\n\\nF', got {next_bytes}"
+    assert next_bytes == b"\n\nP", f"Expected exactly '\\n\\nP', got {next_bytes}"

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -16,4 +16,4 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
-    assert tokens == [b'F', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'D', b'C', b'E']

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -17,4 +17,4 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
-    assert tokens == [b'F', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'D', b'C', b'E']

--- a/tests/test_chunk_F_first_c.py
+++ b/tests/test_chunk_F_first_c.py
@@ -2,11 +2,11 @@ import os, subprocess, sys
 from pathlib import Path
 from tests.conftest import get_chunk_start
 
-def test_c_writer_emits_F_first(tmp_path, monkeypatch):
+def test_c_writer_emits_P_first(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'c')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
     cutoff = get_chunk_start(data)
-    assert data[cutoff:cutoff+1] == b'F'
+    assert data[cutoff:cutoff+1] == b'P'

--- a/tests/test_chunk_F_first_py.py
+++ b/tests/test_chunk_F_first_py.py
@@ -2,7 +2,7 @@ import os, subprocess, sys
 from pathlib import Path
 from tests.conftest import get_chunk_start
 
-def test_py_writer_emits_F_first(tmp_path, monkeypatch):
+def test_py_writer_emits_P_first(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'py')
     monkeypatch.setenv('PYNTP_FORCE_PY', '1')
@@ -10,4 +10,4 @@ def test_py_writer_emits_F_first(tmp_path, monkeypatch):
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/cg_example.py'])
     data = out.read_bytes()
     cutoff = get_chunk_start(data)
-    assert data[cutoff:cutoff+1] == b'F'
+    assert data[cutoff:cutoff+1] == b'P'

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -22,10 +22,6 @@ def test_c_writer_chunks(tmp_path):
         tokens.append(tok)
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens == [b'F', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'D', b'C', b'E']
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
-    f_pos = chunks.index(b"F")
-    fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
-    flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")
-    assert fid == 0 and (flags & 0x10)

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -21,4 +21,4 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         tags.append(data[off:off+1])
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length
-    assert tags == [b'F',b'S',b'D',b'C',b'E'], f"Got {tags!r}"
+    assert tags == [b'P',b'S',b'D',b'C',b'E'], f"Got {tags!r}"

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -22,19 +22,6 @@ def test_py_writer_chunks(tmp_path):
         tokens.append(tok)
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length
-    assert tokens == [b"F", b"S", b"D", b"C", b"E"]
+    assert tokens == [b"P", b"S", b"D", b"C", b"E"]
     assert b"A" not in tokens
-    f_pos = chunks.index(b"F")
-    fid = int.from_bytes(chunks[f_pos + 5 : f_pos + 9], "little")
-    flags = int.from_bytes(chunks[f_pos + 9 : f_pos + 13], "little")
-    assert fid == 0 and flags & 0x10
-    flen = int.from_bytes(chunks[f_pos + 1 : f_pos + 5], "little")
-    script_path = Path(__file__).resolve().parents[1] / "src" / "pynytprof" / "tracer.py"
-    st = script_path.stat()
-    payload = (
-        struct.pack("<IIII", 0, 0x10, st.st_size, int(st.st_mtime))
-        + str(script_path).encode()
-        + b"\0"
-    )
-    assert flen == len(payload)
     assert data.endswith(b"E\x00\x00\x00\x00")

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -23,4 +23,4 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         tags.append(data[off : off + 1])
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
-    assert tags == [b"F", b"S", b"D", b"C", b"E"], f"Got {tags!r}"
+    assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Got {tags!r}"

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -16,4 +16,4 @@ def test_c_writer_chunk_sequence(tmp_path):
         tokens.append(data[off:off+1])
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
-    assert tokens == [b'F', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'D', b'C', b'E']

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -24,7 +24,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\n\n') + 2
-    # skip F and S
+    # skip P and S
     for _ in range(2):
         length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
         idx += 5 + length

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -26,4 +26,4 @@ def test_ascii_header(tmp_path, writer):
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
     cutoff = get_chunk_start(data)
-    assert data[cutoff:cutoff + 1] == b"F"
+    assert data[cutoff:cutoff + 1] == b"P"

--- a/tests/test_header_ascii.py
+++ b/tests/test_header_ascii.py
@@ -21,7 +21,7 @@ def test_ascii_header(tmp_path, writer):
     hdr_end = data.index(b"\n", data.index(b"\n", data.index(b"\n") + 1) + 1) + 1
     assert b"\0" not in data[:hdr_end]
     cutoff = get_chunk_start(data)
-    assert data[cutoff:cutoff + 1] == b"F"
+    assert data[cutoff:cutoff + 1] == b"P"
 
 
 def test_header_banner(tmp_path):

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import subprocess, os, sys
 from tests.conftest import get_chunk_start
 
-def test_first_token_is_F(tmp_path):
+def test_first_token_is_P(tmp_path):
     out = tmp_path / 'nytprof.out'
     env = {
         **os.environ,
@@ -17,5 +17,5 @@ def test_first_token_is_F(tmp_path):
     ], env=env)
     data = out.read_bytes()
     cutoff = get_chunk_start(data)
-    assert data[cutoff] == 0x46  # 'F'
+    assert data[cutoff] == 0x50  # 'P'
     assert data[cutoff - 1] == 0x0A  # banner ends with a blank line

--- a/tests/test_no_extra_newline_before_first_chunk.py
+++ b/tests/test_no_extra_newline_before_first_chunk.py
@@ -21,5 +21,5 @@ def test_no_extra_newline_before_first_chunk(tmp_path):
     ], env=env)
     data = out.read_bytes()
     idx = data.index(b'\n\n')
-    assert data[idx+2:idx+3] == b'F', f"Found {data[idx+2:idx+3]!r} before first chunk"
+    assert data[idx+2:idx+3] == b'P', f"Found {data[idx+2:idx+3]!r} before first chunk"
 

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -16,9 +16,9 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\n\n')+2
-    # skip F
-    flen = int.from_bytes(data[idx+1:idx+5],'little')
-    idx += 5+flen
+    # skip P
+    plen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5+plen
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -16,9 +16,9 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\n\n')+2
-    # skip F
-    flen = int.from_bytes(data[idx+1:idx+5],'little')
-    idx += 5+flen
+    # skip P
+    plen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5+plen
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -31,4 +31,4 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
 
-    assert tags == [b"F", b"S", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"
+    assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -25,7 +25,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         tags.append(tag)
         seen[tag] = seen.get(tag, 0) + 1
         off += 5 + length
-    assert tags == [b'F', b'S', b'D', b'C', b'E'], f"Tags: {tags!r}"
-    assert seen[b'F'] == 1 and seen[b'S'] == 1 and seen[b'D'] == 1 and seen[b'C'] == 1 and seen[b'E'] == 1
+    assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Tags: {tags!r}"
+    assert seen[b'P'] == 1 and seen[b'S'] == 1 and seen[b'D'] == 1 and seen[b'C'] == 1 and seen[b'E'] == 1
     assert all(seen[t] == 1 for t in tags)
     assert all(l > 0 for t, l in seen.items() if t != b'E')

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -30,7 +30,7 @@ def test_schunk(tmp_path, writer):
         if tok == b"S":
             s_off = off
         off += 5 + length
-    assert tokens == [b"F", b"S", b"D", b"C", b"E"]
+    assert tokens == [b"P", b"S", b"D", b"C", b"E"]
     assert s_off is not None
     slen = int.from_bytes(chunks[s_off + 1 : s_off + 5], "little")
     assert slen % 28 == 0 and slen > 0

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tests.conftest import get_chunk_start
 
 
-def test_only_one_F_chunk(tmp_path, monkeypatch):
+def test_no_F_chunk(tmp_path, monkeypatch):
     out = tmp_path / 'nytprof.out'
     monkeypatch.setenv('PYNYTPROF_WRITER', 'py')
     monkeypatch.setenv('PYNTP_FORCE_PY', '1')
@@ -18,4 +18,4 @@ def test_only_one_F_chunk(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     f_count = sum(1 for t in tags if t == b'F')
-    assert f_count == 1, f'Expected exactly one F chunk, found {f_count}'
+    assert f_count == 0, f'Expected no F chunk, found {f_count}'

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -55,7 +55,7 @@ def test_file_chunk_uses_string_indexes(tmp_path):
     assert after[0:1] == b"T"
     t_len = struct.unpack_from("<I", after, 1)[0]
     offset = 5 + t_len
-    assert after[offset : offset + 1] == b"F"
+    tag = after[offset : offset + 1]
     f_len = struct.unpack_from("<I", after, offset + 1)[0]
     payload = after[offset + 5 : offset + 5 + f_len]
     payload = zlib.decompress(payload)


### PR DESCRIPTION
## Summary
- update tests for new `P,S,D,C,E` chunk order
- drop checks that expect `F` chunks

## Testing
- `pytest -n auto` *(fails: 21 failed, 51 passed, 12 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687383004e18833198ed1e1c4544cb10