### PR TITLE
Ensure single newline before P record

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -133,15 +133,20 @@ class Writer:
 
     def _write_header(self) -> None:
         banner = _make_ascii_header(self._start_ns)
+        # banner is guaranteed to end with a single LF
+        assert banner.endswith(b"\n")
         self._fh.write(banner)
+
         import os, struct, time
+
         if os.getenv("PYNYTPROF_DEBUG"):
             print(f"DEBUG: banner_end={banner[-9:]}", file=sys.stderr)
+
         start_us = int(time.time() * 1e6)
-        payload = struct.pack('<QII', start_us, os.getpid(), os.getppid())
-        length = struct.pack('<I', len(payload))
-        self._fh.write(b'P' + length + payload)
+        payload = struct.pack("<QII", start_us, os.getpid(), os.getppid())
+        self._fh.write(b"P" + len(payload).to_bytes(4, "little") + payload)
         self.header_size = len(banner) + 1 + 4 + len(payload)
+
         if os.getenv("PYNYTPROF_DEBUG"):
             print(
                 f"DEBUG: header_size={self.header_size} first_token=P",

--- a/tests/test_single_lf_before_p.py
+++ b/tests/test_single_lf_before_p.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+
+def test_single_lf_before_p(tmp_path):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    subprocess.check_call([
+        sys.executable,
+        '-m', 'pynytprof.tracer',
+        '-o', str(out),
+        '-e', 'pass',
+    ], env=env)
+    data = out.read_bytes()
+    idx = data.index(b'\nP')
+    assert data[idx:idx+2] == b'\nP'
+    assert b'\n\nP' not in data
+


### PR DESCRIPTION
## Summary
- add test verifying only one newline precedes the first `P` chunk
- assert banner ends with a single LF and emit `P` payload directly

## Testing
- `pytest tests/test_single_lf_before_p.py -n auto`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68739f68a3c48331afa15df3ed94605b