### PR TITLE
Fix P record: drop length field; header now valid for NYTProf

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -93,7 +93,7 @@ class Writer:
             b"C": bytearray(),
         }
         self._chunk_order = [b"S", b"D", b"C", b"E"]
-        self.header_size = len(_make_ascii_header(self._start_ns)) + 21
+        self.header_size = len(_make_ascii_header(self._start_ns)) + 17
         if os.getenv("PYNYTPROF_DEBUG"):
             print("DEBUG: Writer initialized with empty buffers", file=sys.stderr)
 
@@ -139,15 +139,15 @@ class Writer:
         assert banner.endswith(b"\n")
         self._fh.write(banner)
 
-        import os, struct, time
+        import os, time
 
         if os.getenv("PYNYTPROF_DEBUG"):
             print(f"DEBUG: banner_end={banner[-9:]}", file=sys.stderr)
 
         start_us = int(time.time() * 1e6)
         payload = struct.pack("<QII", start_us, os.getpid(), os.getppid())
-        self._fh.write(b"P" + len(payload).to_bytes(4, "little") + payload)
-        self.header_size = len(banner) + 1 + 4 + len(payload)
+        self._fh.write(b"P" + payload)
+        self.header_size = len(banner) + 1 + len(payload)
 
         if os.getenv("PYNYTPROF_DEBUG"):
             print(
@@ -298,7 +298,7 @@ def write(
         import os, struct, time
         start_us = int(time.time() * 1e6)
         payload = struct.pack('<QII', start_us, os.getpid(), os.getppid())
-        f.write(b'P' + struct.pack('<I', len(payload)) + payload)
+        f.write(b'P' + payload)
         if not files:
             script = Path(sys.argv[0]).resolve()
             st = script.stat()

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -109,10 +109,7 @@ static void emit_header(FILE *fp) {
     put_u64le(payload, start_us);
     put_u32le(payload + 8, (uint32_t)getpid());
     put_u32le(payload + 12, (uint32_t)getppid());
-    unsigned char lenbuf[4];
-    put_u32le(lenbuf, 16);
     fputc('P', fp);
-    fwrite(lenbuf, 1, 4, fp);
     fwrite(payload, 1, 16, fp);
 
 }

--- a/src/pynytprof/convert.py
+++ b/src/pynytprof/convert.py
@@ -30,13 +30,20 @@ def _parse(path: str) -> tuple[dict, dict, dict, list, list]:
     defs: dict[int, dict] = {}
     calls: list[tuple[int, int, int, int, int]] = []
     lines: list[tuple[int, int, int, int, int]] = []
+    first = True
     while off < len(data):
         tok = data[off : off + 1].decode()
         off += 1
-        length = struct.unpack_from("<I", data, off)[0]
-        off += 4
-        payload = data[off : off + length]
-        off += length
+        if first and tok == "P":
+            payload = data[off : off + 16]
+            off += 16
+            first = False
+            length = 16
+        else:
+            length = struct.unpack_from("<I", data, off)[0]
+            off += 4
+            payload = data[off : off + length]
+            off += length
         if tok == "A":
             attrs = {
                 k.decode(): int(v)

--- a/src/pynytprof/verify.py
+++ b/src/pynytprof/verify.py
@@ -53,17 +53,25 @@ def verify(path: str, quiet: bool = False) -> bool:
                             raise ValueError("truncated attrs")
             last = None
             count = 0
+            first = True
             while True:
                 tag = f.read(1)
                 if not tag:
                     raise ValueError("truncated tag")
-                length_b = f.read(4)
-                if len(length_b) != 4:
-                    raise ValueError("truncated length")
-                length = struct.unpack("<I", length_b)[0]
-                payload = f.read(length)
-                if len(payload) != length:
-                    raise ValueError("truncated payload")
+                if first and tag == b"P":
+                    payload = f.read(16)
+                    if len(payload) != 16:
+                        raise ValueError("truncated payload")
+                    length = 16
+                    first = False
+                else:
+                    length_b = f.read(4)
+                    if len(length_b) != 4:
+                        raise ValueError("truncated length")
+                    length = struct.unpack("<I", length_b)[0]
+                    payload = f.read(length)
+                    if len(payload) != length:
+                        raise ValueError("truncated payload")
                 count += 1
                 last = tag
                 if tag == b"E":

--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -18,6 +18,10 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
     off = idx
     while off < len(data):
         tag = data[off:off+1]
+        if tag == b"P":
+            seen[tag] = 16
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], "little")
         seen[tag] = length
         off += 5 + length

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -13,7 +13,11 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
     tags=[]
     off=idx
     while off < len(data):
-        tags.append(data[off:off+1])
+        tok = data[off:off+1]
+        tags.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5+length
     assert b'S' in tags, f"S chunk missing, only saw {tags!r}"

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -21,8 +21,7 @@ def test_callgraph_py(tmp_path):
     )
     data = out.read_bytes()
     start = get_chunk_start(data)
-    p_len = struct.unpack_from("<I", data, start + 1)[0]
-    off = start + 5 + p_len
+    off = start + 17
     d_pos = data.index(b"D", off)
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
     assert d_len >= 1

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -13,7 +13,11 @@ def test_c_writer_emits_C_chunk(tmp_path):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert b"C" in tokens

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -12,7 +12,11 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[3] == b'C'

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -13,7 +13,11 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[3] == b'C'

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -13,7 +13,11 @@ def test_c_writer_emits_D_chunk(tmp_path):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert b"D" in tokens

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -12,7 +12,11 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[2] == b'D'

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -13,7 +13,11 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[2] == b'D'

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -12,7 +12,11 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -13,7 +13,11 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -12,7 +12,11 @@ def test_c_writer_emits_S_second(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[1] == b'S'

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -13,7 +13,11 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[1] == b'S'

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -20,6 +20,9 @@ def test_c_writer_chunks(tmp_path):
     while off < len(chunks):
         tok = chunks[off:off+1]
         tokens.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
     assert tokens == [b'P', b'S', b'D', b'C', b'E']

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -18,7 +18,11 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
     tags = []
     off = cutoff
     while off < len(data):
-        tags.append(data[off:off+1])
+        tok = data[off:off+1]
+        tags.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length
     assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Got {tags!r}"

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -20,6 +20,9 @@ def test_py_writer_chunks(tmp_path):
     while off < len(chunks):
         tok = chunks[off:off+1]
         tokens.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length
     assert tokens == [b"P", b"S", b"D", b"C", b"E"]

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -20,7 +20,11 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
     tags = []
     off = idx
     while off < len(data):
-        tags.append(data[off : off + 1])
+        tok = data[off : off + 1]
+        tags.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
     assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Got {tags!r}"

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -13,7 +13,11 @@ def test_c_writer_chunk_sequence(tmp_path):
     tokens = []
     off = cutoff
     while off < len(data):
-        tokens.append(data[off:off+1])
+        tok = data[off:off+1]
+        tokens.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert tokens == [b'P', b'S', b'D', b'C', b'E']

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -24,10 +24,9 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    # skip P and S
-    for _ in range(2):
-        length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
-        idx += 5 + length
+    idx += 17  # skip P
+    length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
+    idx += 5 + length
     assert data[idx : idx + 1] == b'D'
     dlen = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     payload = data[idx + 5 : idx + 5 + dlen]

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -15,9 +15,9 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    for _ in range(2):
-        length = int.from_bytes(data[idx+1:idx+5],'little')
-        idx += 5 + length
+    idx += 17
+    length = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5 + length
     assert data[idx:idx+1]==b'D'
     dlen = int.from_bytes(data[idx+1:idx+5],'little')
     assert dlen > 1, f"D chunk too small ({dlen}); no records collected"

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -11,7 +11,11 @@ def _tokens(out):
     toks = []
     off = cutoff
     while off < len(data):
-        toks.append(data[off:off+1])
+        tok = data[off:off+1]
+        toks.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     return b''.join(toks)

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -16,9 +16,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    # skip P
-    plen = int.from_bytes(data[idx+1:idx+5],'little')
-    idx += 5+plen
+    idx += 17  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -16,9 +16,7 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    # skip P
-    plen = int.from_bytes(data[idx+1:idx+5],'little')
-    idx += 5+plen
+    idx += 17  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -28,6 +28,9 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
     while off < len(data):
         tag = data[off : off + 1]
         tags.append(tag)
+        if tag == b"P":
+            off += 17
+            continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
 

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -1,0 +1,25 @@
+import os, subprocess, sys
+from pathlib import Path
+import pytest
+
+def test_p_record_length(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        "-o",
+        str(out),
+        "-e",
+        "pass",
+    ], env=env)
+    data = out.read_bytes()
+    idx = data.index(b"\nP") + 1
+    assert data[idx:idx+17][0] == 0x50
+    assert data[idx+17:idx+18] in (b"S", b"C")
+

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -21,8 +21,12 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
     off = idx
     while off < len(data):
         tag = data[off:off+1]
-        length = int.from_bytes(data[off+1:off+5], 'little')
         tags.append(tag)
+        if tag == b'P':
+            off += 17
+            seen[tag] = seen.get(tag, 0) + 1
+            continue
+        length = int.from_bytes(data[off+1:off+5], 'little')
         seen[tag] = seen.get(tag, 0) + 1
         off += 5 + length
     assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Tags: {tags!r}"

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -26,6 +26,9 @@ def test_schunk(tmp_path, writer):
     while off < len(chunks):
         tok = chunks[off : off + 1]
         tokens.append(tok)
+        if tok == b"P":
+            off += 17
+            continue
         length = int.from_bytes(chunks[off + 1 : off + 5], "little")
         if tok == b"S":
             s_off = off

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -14,7 +14,11 @@ def test_one_F_chunk(tmp_path, monkeypatch):
     tags = []
     off = cutoff
     while off < len(data):
-        tags.append(data[off:off+1])
+        tok = data[off:off+1]
+        tags.append(tok)
+        if tok == b'P':
+            off += 17
+            continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     f_positions = [i for i, t in enumerate(tags) if t == b'F']


### PR DESCRIPTION
## Summary
- ensure the P record does not include a bogus length field
- adjust Python and C writers to emit 17‑byte P record
- update reader, verify and converter for new layout
- fix tests and add regression test for P record size

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6873af43c1d483318153b9de60888e88