### PR TITLE
Fix P chunk length

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -148,8 +148,7 @@ class Writer:
         ppid = os.getppid()
         ts = time.time()
         payload = struct.pack("<II", pid, ppid) + struct.pack("<d", ts)
-        length_bytes = struct.pack("<I", 16)
-        self._fh.write(b"P" + length_bytes + payload)
+        self._fh.write(b"P" + b"\x10\x00\x00\x00" + payload)
         self.header_size = len(banner) + 1 + 4 + 16
 
         if os.getenv("PYNYTPROF_DEBUG"):

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -119,8 +119,7 @@ static void emit_header(FILE *fp) {
     put_u32le(payload + 4, (uint32_t)getppid());
     put_double_le(payload + 8, t);
     fputc('P', fp);
-    uint32_t len = 16;
-    fwrite(&len, 4, 1, fp);
+    fwrite("\x10\x00\x00\x00", 1, 4, fp);
     fwrite(payload, 1, 16, fp);
 
 }

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import importlib.util
+import pytest
+
+
+@pytest.mark.parametrize("writer", ["py", "c"])
+def test_p_length_is_16(tmp_path, writer):
+    env = os.environ.copy()
+    env["PYNYTPROF_WRITER"] = writer
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    if writer == "c" and importlib.util.find_spec("pynytprof._cwrite") is None:
+        pytest.skip("_cwrite missing")
+    out = tmp_path / "nytprof.out"
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        "-o",
+        str(out),
+        "-e",
+        "pass",
+    ], env=env)
+    data = out.read_bytes()
+    idx = data.index(b"\nP") + 1
+    hdr = data[idx:idx + 5]
+    assert hdr == b"P\x10\x00\x00\x00"


### PR DESCRIPTION
## Summary
- add regression test ensuring P-record length is always 16 bytes
- hard-code the 16-byte length in the Python writer
- do the same in the C writer

## Testing
- `pip install -e .[dev]`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6873c2eb04c88331a37bb0cceb3f9822