### PR TITLE
Add debug TLV parser to writer

### DIFF
--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -153,7 +153,9 @@ def _write_nytprof(out_path: Path) -> None:
         if not emitted_c:
             w.write_chunk(b"C", b"")
     finally:
-        if getattr(w, "close", None):
+        if getattr(w, "finalize", None):
+            w.finalize()
+        elif getattr(w, "close", None):
             w.close()
 
 


### PR DESCRIPTION
## Summary
- add finalize() to `_pywrite.Writer` that validates TLV boundaries when `PYNYTPROF_DEBUG` is set
- ensure context managers call `finalize`
- invoke finalize from tracer when profiling scripts

## Testing
- `pytest -n auto`
- `PYTHONPATH=src PYNYTPROF_DEBUG=1 PYNYTPROF_WRITER=py python -m pynytprof.tracer tests/example_script.py`


------
https://chatgpt.com/codex/tasks/task_e_6873c9f178fc833185ce85561fb79b72