### PR TITLE
Add P-record debug output

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -157,6 +157,7 @@ class Writer:
                 f"DEBUG: P-payload raw={binascii.hexlify(payload)}",
                 file=sys.stderr,
             )
+            self._debug_chunk_info(b"P", payload, self.header_size)
         self._fh.write(b"P" + payload)
         self.header_size = len(banner) + 1 + len(payload)
 
@@ -286,8 +287,16 @@ class Writer:
         print("DEBUG: TLV parse check on", fpath)
         with open(fpath, "rb") as fh:
             data = fh.read()
-        i = self.header_size
+        banner_len = self.header_size - 17  # account for P record (17 bytes)
+        i = banner_len
         chunk = 1
+        if data[i:i+1] == b"P":
+            length = 16
+            print(
+                f"DEBUG: chunk {chunk} tag={data[i:i+1]!r} offset=0x{i:x} len={length}"
+            )
+            i += 1 + length
+            chunk += 1
         while i < len(data):
             tag = data[i : i + 1]
             if tag == b"":

--- a/tests/test_debug_p_record.py
+++ b/tests/test_debug_p_record.py
@@ -1,0 +1,18 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_debug_p_record(tmp_path):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYNTP_FORCE_PY': '1',
+        'PYNYTPROF_DEBUG': '1',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
+        env=env, stderr=subprocess.PIPE, text=True
+    )
+    assert 'buffering chunk tag=P' in proc.stderr


### PR DESCRIPTION
## Summary
- show P-record details via `_debug_chunk_info`
- include P chunk in TLV parsing when debugging
- test that debug logs mention the P record

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6873d8c7ce5c8331aa9c0f42da18b714