### PR TITLE
Writer: manual TLV write for P record (include length); drop buffer_chunk for P

### DIFF
--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -16,7 +16,7 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 16
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -16,10 +16,8 @@ def test_c_writer_emits_C_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            if data[off+1:off+5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -15,10 +15,8 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -16,10 +16,8 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -16,10 +16,8 @@ def test_c_writer_emits_D_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            if data[off+1:off+5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -15,10 +15,8 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -16,10 +16,8 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -15,10 +15,8 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -16,10 +16,8 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -15,10 +15,8 @@ def test_c_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -16,10 +16,8 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -21,10 +21,8 @@ def test_c_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            if chunks[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert chunks[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -21,10 +21,8 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -21,10 +21,8 @@ def test_py_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            if chunks[off+1:off+5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert chunks[off+1:off+5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -23,10 +23,8 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         tok = data[off : off + 1]
         tags.append(tok)
         if tok == b"P":
-            if data[off + 1 : off + 5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off + 1 : off + 5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -16,10 +16,8 @@ def test_c_writer_chunk_sequence(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            if data[off+1:off+5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -24,7 +24,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P
+    idx += 21  # skip P
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
     assert data[idx : idx + 1] == b'D'

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -15,7 +15,7 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17
+    idx += 21
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
     assert data[idx:idx+1]==b'D'

--- a/tests/test_debug_p_record.py
+++ b/tests/test_debug_p_record.py
@@ -15,4 +15,4 @@ def test_debug_p_record(tmp_path):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'buffering chunk tag=P' in proc.stderr
+    assert 'DEBUG: wrote P TLV' in proc.stderr

--- a/tests/test_fchunk_no_newlines.py
+++ b/tests/test_fchunk_no_newlines.py
@@ -19,5 +19,5 @@ def test_pchunk_no_newlines(tmp_path):
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
     assert data[idx:idx+1] == b'P'
-    payload = data[idx+1:idx+17]
+    payload = data[idx+5:idx+21]
     assert b'\n' not in payload

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -14,11 +14,9 @@ def _tokens(out):
         tok = data[off:off+1]
         toks.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                length = int.from_bytes(data[off+1:off+5], 'little')
-                off += 5 + length
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            length = int.from_bytes(data[off+1:off+5], 'little')
+            off += 5 + length
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pynytprof._pywrite import Writer
+
+
+def test_no_buffer_chunk_for_p(tmp_path):
+    out = tmp_path / "nytprof.out"
+    with Writer(str(out)):
+        pass
+    data = out.read_bytes()
+    assert b"\nP\x10\x00\x00\x00" in data
+    for i in range(256):
+        if i == 0x10:
+            continue
+        assert b"\nP" + bytes([i]) not in data

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -16,7 +16,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P
+    idx += 21  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -16,7 +16,7 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P
+    idx += 21  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -29,10 +29,8 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         tag = data[off : off + 1]
         tags.append(tag)
         if tag == b"P":
-            if data[off + 1 : off + 5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off + 1 : off + 5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -22,7 +22,7 @@ def test_p_length_is_16(tmp_path, writer):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    payload = data[idx+1:idx+17]
+    payload = data[idx+5:idx+21]
     assert len(payload) == 16
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == os.getpid()

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -22,7 +22,7 @@ def test_p_record_format(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    payload = data[idx + 1 : idx + 17]
+    payload = data[idx + 5 : idx + 21]
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == p.pid
     assert ppid == os.getpid()

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -21,5 +21,5 @@ def test_p_record_length(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+17:idx+18] in (b"S", b"C")
+    assert data[idx+21:idx+22] in (b"S", b"C")
 

--- a/tests/test_p_record_tlv_bytes.py
+++ b/tests/test_p_record_tlv_bytes.py
@@ -13,7 +13,7 @@ def test_p_record_tlv_bytes(tmp_path):
     data = out.read_bytes()
     i = data.index(b"\nP") + 1
     assert data[i:i+1] == b"P"
-    payload = data[i+1:i+17]
+    payload = data[i+5:i+21]
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == os.getpid()
     assert ppid == os.getppid()

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -23,10 +23,8 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         tag = data[off:off+1]
         tags.append(tag)
         if tag == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             seen[tag] = seen.get(tag, 0) + 1
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')

--- a/tests/test_s_offset_after_p.py
+++ b/tests/test_s_offset_after_p.py
@@ -13,7 +13,7 @@ def test_s_offset_after_p(tmp_path):
     tracer.profile_command("pass", out_path=out)
     data = out.read_bytes()
     banner_end = data.index(b'!evals=0\n') + len(b'!evals=0\n')
-    pid, ppid, ts = struct.unpack('<IId', data[banner_end+1:banner_end+17])
-    expected_s_offset = banner_end + 1 + 16
+    pid, ppid, ts = struct.unpack('<IId', data[banner_end+1+4:banner_end+1+4+16])
+    expected_s_offset = banner_end + 1 + 4 + 16
     idx = data.index(b'S', banner_end)
     assert idx == expected_s_offset

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -27,10 +27,8 @@ def test_schunk(tmp_path, writer):
         tok = chunks[off : off + 1]
         tokens.append(tok)
         if tok == b"P":
-            if chunks[off + 1 : off + 5] == b"\x10\x00\x00\x00":
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert chunks[off + 1 : off + 5] == b"\x10\x00\x00\x00"
+            off += 5 + 16
             continue
         length = int.from_bytes(chunks[off + 1 : off + 5], "little")
         if tok == b"S":

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -17,10 +17,8 @@ def test_one_F_chunk(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            if data[off+1:off+5] == b'\x10\x00\x00\x00':
-                off += 5 + 16
-            else:
-                off += 1 + 16
+            assert data[off+1:off+5] == b'\x10\x00\x00\x00'
+            off += 5 + 16
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length


### PR DESCRIPTION
## Summary
- manual TLV write for P record
- adjust header size and debug output
- update finalize logic for new length
- fix tests for new TLV format
- add check ensuring buffer_chunk isn't used for P

## Testing
- `pytest -n auto`
- `PYNYTPROF_DEBUG=1 PYTHONPATH=src python -m pynytprof.tracer -o nytprof.out -e pass`
- `nytprofhtml nytprof.out` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_6873ddb363fc8331b1886132edd8cbf2