### PR TITLE
Remove duplicate P TLV buffering, add test

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -157,10 +157,19 @@ class Writer:
                 f"DEBUG: P-payload raw={binascii.hexlify(payload)}",
                 file=sys.stderr,
             )
-            self._debug_chunk_info(b"P", payload, self.header_size)
         length_bytes = struct.pack("<I", len(payload))
         self._fh.write(b"P" + length_bytes + payload)
         self.header_size = len(banner) + 1 + 4 + len(payload)
+        if os.getenv("PYNYTPROF_DEBUG"):
+            self._fh.flush()
+            with open(self._fh.name, "rb") as f:
+                data = f.read()
+            banner_len = len(banner)
+            print(
+                "DEBUG: after header, first5=",
+                data[banner_len : banner_len + 5].hex(),
+                file=sys.stderr,
+            )
 
         if os.getenv("PYNYTPROF_DEBUG"):
             print(

--- a/tests/test_single_p_tlv.py
+++ b/tests/test_single_p_tlv.py
@@ -1,0 +1,15 @@
+import struct, os, subprocess, sys
+from pathlib import Path
+
+
+def test_single_p_tlv(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
+    data = out.read_bytes()
+    occurrences = [i for i in range(len(data)) if data[i:i+5] == b"P\x10\x00\x00\x00"]
+    assert len(occurrences) == 1, f"Expected exactly one P TLV, found {len(occurrences)}"


### PR DESCRIPTION
## Summary
- ensure tracer only writes one `P` TLV
- print first bytes after header when debugging

## Testing
- `pytest -n auto`
- `PYNYTPROF_DEBUG=1 PYTHONPATH=src python -m pynytprof.tracer -o nytprof.out -e pass`

------
https://chatgpt.com/codex/tasks/task_e_6874102be2f88331aec4e57fcb036bdb