### PR TITLE
Drop buffered P chunk; enforce debug check

### DIFF
--- a/tests/test_no_buffered_P_chunk.py
+++ b/tests/test_no_buffered_P_chunk.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+def test_no_buffered_P_chunk(tmp_path):
+    out = tmp_path / "nytprof.out"
+    log = tmp_path / "nytprof.log"
+    env = {
+        **os.environ,
+        "PYNYTPROF_DEBUG": "1",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    with log.open("w") as fh:
+        subprocess.check_call(
+            [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
+            env=env,
+            stderr=fh,
+        )
+    logs = log.read_text()
+    assert "buffering chunk tag=P" not in logs, f"Found buffered P chunk in logs: {logs}"
+


### PR DESCRIPTION
## Summary
- add regression test ensuring `P` chunk isn't buffered
- rely solely on the manual TLV write

## Testing
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_6874138fd4108331b7c4b3ef1c4e38c9