### PR TITLE
Remove length prefix from P record

### DIFF
--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -36,7 +36,7 @@ NYTProf <major> <minor>\n
 Most records are **TLV** → `tag:u8` + `len:u32(le)` + `payload`.
 
 **Sequence**
-1. `P`  process-start (21 bytes total)
+1. `P`  process-start (17 bytes total)
 2. `S`  statement samples
 3. `D`  sub-descriptors
 4. `C`  call-graph edges

--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -146,9 +146,8 @@ class Writer:
 
         pid = os.getpid()
         ppid = os.getppid()
-        ts = time.time()
+        payload = struct.pack("<IId", pid, ppid, time.time())
         import binascii
-        payload = struct.pack("<II", pid, ppid) + struct.pack("<d", ts)
         assert len(payload) == 16, f"P payload wrong length: {len(payload)}"
         if os.getenv("PYNYTPROF_DEBUG"):
             print(
@@ -172,7 +171,7 @@ class Writer:
                 file=sys.stderr,
             )
             print(
-                f"DEBUG: wrote P TLV, len=16, pid={pid},ppid={ppid},ts={ts:.6f}",
+                f"DEBUG: wrote P record (17 bytes) pid={pid} ppid={ppid}",
                 file=sys.stderr,
             )
             print(

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -1,27 +1,16 @@
-import struct
-import subprocess, os, sys
-from pathlib import Path
+import os, subprocess, sys
 
-
-def test_p_record_17_bytes(tmp_path):
-    out = tmp_path / "nytprof.out"
-    env = {
-        **os.environ,
-        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
-    }
+def test_p_record_is_17_bytes(tmp_path):
+    out = tmp_path/"nytprof.out"
+    env = {**os.environ, "PYNYTPROF_WRITER": "py"}
     subprocess.check_call([
         sys.executable,
-        "-m",
-        "pynytprof.tracer",
-        "-o",
-        str(out),
-        "-e",
-        "pass",
+        "-m", "pynytprof.tracer",
+        "-o", str(out), "-e", "pass"
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
-    assert data[idx] == 0x50
-    pid, ppid, ts = struct.unpack("<II", data[idx+1:idx+9]) + (
-        struct.unpack("<d", data[idx+9:idx+17])[0],
-    )
-    assert idx + 17 == data.index(b"S", idx)
+    idx = data.index(b'\nP') + 1
+    payload = data[idx+1:idx+17]
+    assert len(payload) == 16
+    assert data[idx+17:idx+18] == b'S'
+


### PR DESCRIPTION
## Summary
- test that the `P` record is exactly 17 bytes and directly followed by `S`
- write process start record without a length prefix
- update debug message
- document new size in FILE_FORMAT spec

## Testing
- `pytest -n auto tests/test_p_record_17_bytes.py`
- `pytest -n auto`
- `PYNYTPROF_DEBUG=1 PYNYTPROF_WRITER=py python -m pynytprof.tracer tests/example_script.py` *(fails: `nytprofhtml` profile load due to incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_6874d090e1648331a545b3f10bc85471