### PR TITLE
Fix P record layout in Python writer

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -89,7 +89,7 @@ class Writer:
         pid = os.getpid()
         ppid = os.getppid()
         start_time_s = time.time()
-        payload = struct.pack("<dII", start_time_s, pid, ppid)
+        payload = struct.pack("<IId", pid, ppid, start_time_s)
         banner_len = len(banner)
         self.header_size = banner_len + 1 + 4 + 16
         if os.getenv("PYNYTPROF_DEBUG"):
@@ -174,7 +174,7 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
         pid = os.getpid()
         ppid = os.getppid()
         ts = time.time()
-        payload = struct.pack("<dII", ts, pid, ppid)
+        payload = struct.pack("<IId", pid, ppid, ts)
         f.write(b"P" + len(payload).to_bytes(4, "little") + payload)
 
         s_payload = b"".join(

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -25,8 +25,6 @@ def test_p_length_is_16(tmp_path, writer):
     assert data[idx+1:idx+5] == (16).to_bytes(4, "little")
     payload = data[idx+5:idx+21]
     assert len(payload) == 16
-    if writer == "py":
-        ts, pid, ppid = struct.unpack("<dII", payload)
-    else:
-        pid, ppid, ts = struct.unpack("<IId", payload)
+    pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == os.getpid()
+    assert ppid == os.getppid()

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -25,7 +25,7 @@ def test_p_record_format(tmp_path):
     length = int.from_bytes(data[idx+1:idx+5], "little")
     assert length == 16
     payload = data[idx + 5 : idx + 21]
-    ts, pid, ppid = struct.unpack("<dII", payload)
+    pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == p.pid
     assert ppid == os.getpid()
     assert abs(ts - time.time()) < 1.0


### PR DESCRIPTION
## Summary
- align py writer's `P` record with spec
- update tests to use new field ordering

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6874f94c6cc48331bddc583200e4a6c9