### PR TITLE
Fix P chunk length handling

### DIFF
--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -19,7 +19,7 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
     while off < len(data):
         tag = data[off:off+1]
         if tag == b"P":
-            off += 17
+            off += 21
             seen[tag] = 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -16,7 +16,7 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -21,7 +21,7 @@ def test_callgraph_py(tmp_path):
     )
     data = out.read_bytes()
     start = get_chunk_start(data)
-    off = start + 17
+    off = start + 21
     d_pos = data.index(b"D", off)
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
     assert d_len >= 1

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -16,7 +16,7 @@ def test_c_writer_emits_C_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -16,7 +16,7 @@ def test_c_writer_emits_D_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -21,7 +21,7 @@ def test_c_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -21,7 +21,7 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -21,7 +21,7 @@ def test_py_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -23,7 +23,7 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         tok = data[off : off + 1]
         tags.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -16,7 +16,7 @@ def test_c_writer_chunk_sequence(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -24,7 +24,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P record
+    idx += 21  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
     assert data[idx : idx + 1] == b'D'

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -15,7 +15,7 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17
+    idx += 21
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
     assert data[idx:idx+1]==b'D'

--- a/tests/test_debug_chunk_summary.py
+++ b/tests/test_debug_chunk_summary.py
@@ -15,4 +15,4 @@ def test_debug_chunk_summary(tmp_path):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'DEBUG: wrote raw P record (17 B)' in proc.stderr
+    assert 'DEBUG: wrote raw P record (21 B)' in proc.stderr

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -20,7 +20,7 @@ def test_exactly_one_p_record(tmp_path):
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
     assert data[idx:idx+1] == b'P'
-    pid_bytes = data[idx+1:idx+5]
+    pid_bytes = data[idx+5:idx+9]
     assert pid_bytes == p.pid.to_bytes(4, 'little')
     s_off = data.index(b'S')
-    assert s_off == idx + 17
+    assert s_off == idx + 21

--- a/tests/test_fchunk_no_newlines.py
+++ b/tests/test_fchunk_no_newlines.py
@@ -21,6 +21,6 @@ def test_pchunk_no_newlines(tmp_path):
     idx = data.index(b'\nP') + 1
     assert data[idx:idx+1] == b'P'
     pid_bytes = p.pid.to_bytes(4, 'little')
-    assert data[idx+1:idx+5] == pid_bytes
-    payload = data[idx+5:idx+17]
+    assert data[idx+5:idx+9] == pid_bytes
+    payload = data[idx+9:idx+21]
     assert b'\n' not in payload

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -14,7 +14,7 @@ def _tokens(out):
         tok = data[off:off+1]
         toks.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -14,5 +14,5 @@ def test_no_buffer_chunk_for_p(tmp_path):
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
     pid_bytes = os.getpid().to_bytes(4, "little")
-    assert data[idx+1:idx+5] == pid_bytes
+    assert data[idx+5:idx+9] == pid_bytes
     assert data.count(b"\nP") == 1

--- a/tests/test_no_newline_bytes_after_header.py
+++ b/tests/test_no_newline_bytes_after_header.py
@@ -13,7 +13,7 @@ def test_no_newline_bytes_after_header(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    split = data.index(b'\nP') + 1 + 1 + 4 + 4 + 8
+    split = data.index(b'\nP') + 1 + 1 + 4 + 4 + 4 + 8
     tail = data[split:]
     # Assert no 0x0A anywhere in the binary section
     pos = tail.find(b'\n')

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -16,7 +16,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P
+    idx += 21  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -16,7 +16,7 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 17  # skip P
+    idx += 21  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -29,7 +29,7 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         tag = data[off : off + 1]
         tags.append(tag)
         if tag == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -22,9 +22,9 @@ def test_p_length_is_16(tmp_path, writer):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    pid = int.from_bytes(data[idx+1:idx+5], "little")
+    pid = int.from_bytes(data[idx+5:idx+9], "little")
     assert pid == os.getpid()
-    payload = data[idx+1:idx+17]
+    payload = data[idx+5:idx+21]
     assert len(payload) == 16
     pid2, ppid, ts = struct.unpack("<IId", payload)
     assert pid2 == os.getpid()

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 
-def test_p_record_is_17_bytes(tmp_path):
+def test_p_record_is_21_bytes(tmp_path):
     out = tmp_path / "nytprof.out"
     env = {
         **os.environ,
@@ -16,4 +16,4 @@ def test_p_record_is_17_bytes(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx + 17 : idx + 18] == b"S"
+    assert data[idx + 21 : idx + 22] == b"S"

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -22,7 +22,7 @@ def test_p_record_format(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    payload = data[idx + 1 : idx + 17]
+    payload = data[idx + 5 : idx + 21]
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == p.pid
     assert ppid == os.getpid()

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -21,5 +21,5 @@ def test_p_record_length(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+17:idx+18] in (b"S", b"C")
+    assert data[idx+21:idx+22] in (b"S", b"C")
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -24,4 +24,4 @@ def test_p_record_raw(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+17:idx+18] == b"S"
+    assert data[idx+21:idx+22] == b"S"

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -23,7 +23,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         tag = data[off:off+1]
         tags.append(tag)
         if tag == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             seen[tag] = seen.get(tag, 0) + 1
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')

--- a/tests/test_s_offset_after_p.py
+++ b/tests/test_s_offset_after_p.py
@@ -22,6 +22,6 @@ def test_s_offset_after_p(tmp_path):
     ], env=env)
     data = out.read_bytes()
     idx_p = data.index(b"\nP") + 1
-    s_expected = idx_p + 1 + 4 + 4 + 8
+    s_expected = idx_p + 1 + 4 + 4 + 4 + 8
     idx_s = data.index(b"S", s_expected - 1)
     assert idx_s == s_expected

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -27,7 +27,7 @@ def test_schunk(tmp_path, writer):
         tok = chunks[off : off + 1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off + 1 : off + 5], "little")
         if tok == b"S":

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -17,7 +17,7 @@ def test_one_F_chunk(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_single_p_record.py
+++ b/tests/test_single_p_record.py
@@ -22,6 +22,6 @@ def test_single_p_record(tmp_path):
     p.wait()
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
-    pid = int.from_bytes(data[idx + 1:idx + 5], "little")
+    pid = int.from_bytes(data[idx + 5:idx + 9], "little")
     assert pid == p.pid
-    assert data[idx + 17:idx + 18] == b"S"
+    assert data[idx + 21:idx + 22] == b"S"

--- a/tests/test_writer_p_chunk.py
+++ b/tests/test_writer_p_chunk.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import io
+import struct
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pynytprof._pywrite import Writer
+
+
+def test_p_chunk_includes_length_field():
+    buf = io.BytesIO()
+    w = Writer(fp=buf)
+    payload = b'ABCDEFGH'
+    w._write_raw_P(payload)
+    data = buf.getvalue()
+    assert data[0:1] == b'P'
+    assert data[1:5] == struct.pack('<I', len(payload))
+    assert data[5:] == payload


### PR DESCRIPTION
## Summary
- verify that P chunk writes a length field before its payload
- update _pywrite.Writer to emit the length field for P chunks
- support passing a file-like object to `Writer`
- adjust tests for the new P chunk layout

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6875050a36508331b8f84dfc7a78ea73