### PR TITLE
Fix parallel test interference

### DIFF
--- a/src/pynytprof/cli.py
+++ b/src/pynytprof/cli.py
@@ -9,7 +9,10 @@ from . import convert, verify
 
 
 def _cmd_profile(args: argparse.Namespace) -> int:
-    cmd = [sys.executable, "-m", "pynytprof.tracer", args.script, *args.args]
+    cmd = [sys.executable, "-m", "pynytprof.tracer"]
+    if args.out:
+        cmd += ["-o", args.out]
+    cmd += [args.script, *args.args]
     proc = subprocess.run(cmd, env=os.environ.copy())
     return proc.returncode
 
@@ -40,6 +43,7 @@ def main(argv: list[str] | None = None) -> None:
     pr = sub.add_parser("profile", help="profile a script")
     pr.add_argument("script")
     pr.add_argument("args", nargs=argparse.REMAINDER)
+    pr.add_argument("-o", "--out")
     pr.add_argument("-q", "--quiet", action="store_true")
     pr.set_defaults(func=_cmd_profile)
 

--- a/src/pynytprof/tracer.py
+++ b/src/pynytprof/tracer.py
@@ -269,7 +269,7 @@ def _trace(frame: FrameType, event: str, arg: Any) -> Any:
     return _trace
 
 
-def profile_script(path: str, out_path: Path | str = "nytprof.out") -> None:
+def profile_script(path: str, out_path: Path | str | None = None) -> None:
     global _script_path, _start_ns, _results, _filters, _line_hits, _emitted_f
     global _stmt_records
     _filters = [p for p in os.environ.get("NYTPROF_FILTER", "").split(",") if p]
@@ -312,6 +312,8 @@ def profile_script(path: str, out_path: Path | str = "nytprof.out") -> None:
     _stack = []
     _call_stack = []
     _stmt_records = []
+    if out_path is None:
+        out_path = f"nytprof.out.{os.getpid()}"
     out_p = Path(out_path)
     sys.settrace(_trace)
     try:
@@ -321,7 +323,7 @@ def profile_script(path: str, out_path: Path | str = "nytprof.out") -> None:
         _write_nytprof(out_p)
 
 
-def profile_command(code: str, out_path: Path | str = "nytprof.out") -> None:
+def profile_command(code: str, out_path: Path | str | None = None) -> None:
     global _script_path, _start_ns, _results, _filters, _line_hits
     global _calls, _call_time_ns, _edge_time_ns, _last_ts, _stack
     global _call_stack, _emitted_f, _stmt_records
@@ -338,6 +340,8 @@ def profile_command(code: str, out_path: Path | str = "nytprof.out") -> None:
     _stack = []
     _call_stack = []
     _stmt_records = []
+    if out_path is None:
+        out_path = f"nytprof.out.{os.getpid()}"
     out_p = Path(out_path)
     sys.settrace(_trace)
     try:
@@ -361,7 +365,12 @@ def cli() -> None:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="pynytprof.tracer")
-    parser.add_argument("-o", "--output", type=Path, default="nytprof.out")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=f"nytprof.out.{os.getpid()}",
+    )
     parser.add_argument("-e", dest="expr", default=None)
     parser.add_argument("script", nargs="?")
     parser.add_argument("args", nargs=argparse.REMAINDER)

--- a/tests/test_cchunks.py
+++ b/tests/test_cchunks.py
@@ -24,12 +24,15 @@ def test_c_chunks(tmp_path, use_c):
         pkg.mkdir(parents=True)
         (pkg / "_cwrite.py").write_text("raise ImportError\n")
         env["PYTHONPATH"] = str(fake) + os.pathsep + env["PYTHONPATH"]
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call([
         sys.executable,
         "-m",
         "pynytprof.tracer",
+        "-o",
+        str(out),
         str(script),
     ], cwd=tmp_path, env=env)
-    data = (tmp_path / "nytprof.out").read_bytes()
+    data = out.read_bytes()
     assert b"C\x00" in data
     assert b"D\x00" in data

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,19 +9,24 @@ def test_convert(tmp_path):
     script = Path(__file__).with_name("example_script.py")
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    out_file = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call([
         sys.executable,
         "-m",
         "pynytprof.tracer",
+        "-o",
+        str(out_file),
         str(script),
     ], cwd=tmp_path, env=env)
+    out_json = tmp_path / "nytprof.speedscope.json"
     subprocess.check_call([
         sys.executable,
         "-m",
         "pynytprof",
         "speedscope",
-        "nytprof.out",
+        out_file.name,
+        "--out",
+        str(out_json),
     ], cwd=tmp_path, env=env)
-    out_json = tmp_path / "nytprof.speedscope.json"
     data = json.loads(out_json.read_text())
     assert data["$schema"] == "https://www.speedscope.app/file-format-schema.json"

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -13,17 +13,20 @@ def run(filter_val, tmp_path):
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
     env["NYTPROF_FILTER"] = filter_val
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call(
         [
             sys.executable,
             "-m",
             "pynytprof.tracer",
+            "-o",
+            str(out),
             str(SCRIPT),
         ],
         cwd=tmp_path,
         env=env,
     )
-    out = tmp_path / "nytprof.out"
+    
     return read(str(out))
 
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -15,7 +15,7 @@ import pytest
 @pytest.mark.parametrize("hide_cwrite", [False, True])
 def test_format(tmp_path, hide_cwrite):
     script = Path(__file__).with_name("example_script.py")
-    out = tmp_path / "nytprof.out"
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
     if hide_cwrite:
@@ -25,7 +25,9 @@ def test_format(tmp_path, hide_cwrite):
         (pkg / "_cwrite.py").write_text("raise ImportError\n")
         env["PYTHONPATH"] = str(fake) + os.pathsep + env["PYTHONPATH"]
     subprocess.check_call(
-        [sys.executable, "-m", "pynytprof.tracer", str(script)], cwd=tmp_path, env=env
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), str(script)],
+        cwd=tmp_path,
+        env=env,
     )
     assert out.exists()
     with out.open("rb") as f:

--- a/tests/test_integration_html.py
+++ b/tests/test_integration_html.py
@@ -28,8 +28,8 @@ def test_nytprofhtml_roundtrip(tmp_path, monkeypatch):
     importlib.reload(tracer)
     monkeypatch.chdir(tmp_path)
 
-    tracer.profile_script(str(script))
-    out = tmp_path / "nytprof.out"
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
+    tracer.profile_script(str(script), out_path=out)
     assert out.exists(), "profiling produced no output file"
 
     res = subprocess.run(

--- a/tests/test_perl_lines.py
+++ b/tests/test_perl_lines.py
@@ -12,17 +12,19 @@ def test_perl_lines(tmp_path):
     script = Path(__file__).with_name("example_script.py")
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    out_file = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call(
         [
             sys.executable,
             "-m",
             "pynytprof.tracer",
+            "-o",
+            str(out_file),
             str(script),
         ],
         cwd=tmp_path,
         env=env,
     )
-    out_file = tmp_path / "nytprof.out"
     cmd = [
         "perl",
         "-MDevel::NYTProf::Data",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,8 +5,15 @@ import os
 
 def test_profile_creates_file(tmp_path):
     script = Path(__file__).with_name('example_script.py')
-    out = tmp_path / 'nytprof.out'
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     env = dict(**os.environ)
     env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1] / 'src')
-    subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', str(script)], cwd=tmp_path, env=env)
+    subprocess.check_call([
+        sys.executable,
+        '-m',
+        'pynytprof.tracer',
+        '-o',
+        str(out),
+        str(script)
+    ], cwd=tmp_path, env=env)
     assert out.exists() and out.stat().st_size >= 8

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -8,16 +8,18 @@ def test_verify(tmp_path):
     script = Path(__file__).with_name("example_script.py")
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call([
         sys.executable,
         "-m",
         "pynytprof",
         "profile",
+        "-o",
+        str(out),
         str(script),
     ], cwd=tmp_path, env=env)
-    out = tmp_path / "nytprof.out"
     proc = subprocess.run(
-        [sys.executable, "-m", "pynytprof", "verify", "nytprof.out"],
+        [sys.executable, "-m", "pynytprof", "verify", out.name],
         cwd=tmp_path,
         env=env,
         text=True,
@@ -28,7 +30,7 @@ def test_verify(tmp_path):
     data = out.read_bytes()
     out.write_bytes(data[:-1] + bytes([data[-1] ^ 0xFF]))
     proc = subprocess.run(
-        [sys.executable, "-m", "pynytprof", "verify", "nytprof.out"],
+        [sys.executable, "-m", "pynytprof", "verify", out.name],
         cwd=tmp_path,
         env=env,
         text=True,

--- a/tests/test_viewer_minimal.py
+++ b/tests/test_viewer_minimal.py
@@ -20,14 +20,15 @@ def test_viewer_minimal(tmp_path):
 
     env = dict(os.environ)
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    out = tmp_path / f"nytprof.out.{os.getpid()}"
     subprocess.check_call(
-        [sys.executable, "-m", "pynytprof.tracer", str(script)],
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), str(script)],
         cwd=tmp_path,
         env=env,
     )
 
     subprocess.check_call(
-        ["nytprofhtml", "-f", "nytprof.out", "-o", "report"],
+        ["nytprofhtml", "-f", out.name, "-o", "report"],
         cwd=tmp_path,
     )
 


### PR DESCRIPTION
## Summary
- avoid collisions by using process ID in default output filename
- allow `pynytprof profile` to accept an `--out` path
- update tests to pass `-o` and expect PID-specific names

## Testing
- `pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_68751358a9b88331ab894b855dd3ffb9