### PR TITLE
Fix C writer P chunk length

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -127,11 +127,12 @@ static void emit_header(FILE *fp) {
     clock_gettime(CLOCK_REALTIME, &ts);
     double t = (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
     fputc('P', fp);
+    store_le32(fp, 16); /* payload length */
     store_le32(fp, (uint32_t)getpid());
     store_le32(fp, (uint32_t)getppid());
     store_le_double(fp, t);
     if (getenv("PYNYTPROF_DEBUG"))
-        fprintf(stderr, "DEBUG: wrote raw P record (17 B)\n");
+        fprintf(stderr, "DEBUG: wrote raw P record (21 B)\n");
 
 }
 


### PR DESCRIPTION
## Summary
- write 4-byte length for P chunk in C writer
- update debug output to mention 21 byte record size

## Testing
- `pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_68751805385c8331abace18394bfb960