### PR TITLE
Detect Perl nvsize at runtime

### DIFF
--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -5,7 +5,7 @@ import struct
 import time
 from pathlib import Path
 
-from ._pywrite import _make_ascii_header, write as _py_write, Writer as _PyWriter
+from ._pywrite import _make_ascii_header, write as _py_write, Writer as _PyWriter, _perl_nv_size
 
 
 class Writer:
@@ -25,6 +25,7 @@ class Writer:
         self._start_ns = self.start_time
         self.tracer = tracer
         self.writer = self
+        self._nv_size = _perl_nv_size()
         self._line_hits: dict[tuple[int, int], tuple[int, int, int]] = {}
         self._buf: dict[bytes, bytearray] = {
             b"F": bytearray(),
@@ -98,7 +99,7 @@ class Writer:
             summary = ", ".join(f"{t.decode()}={len(buf)}" for t, buf in self._buf.items())
             print(f"FINAL CHUNKS: {summary}", file=sys.stderr)
 
-        hdr = _make_ascii_header(self._start_ns)
+        hdr = _make_ascii_header(self._start_ns, self._nv_size)
         data = hdr
         if os.getenv("PYNYTPROF_DEBUG"):
             print(f"DEBUG: about to write raw data of length={len(data)}", file=sys.stderr)

--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 def test_S_and_D_non_empty(tmp_path, monkeypatch):
     out = tmp_path/'nytprof.out'
@@ -19,8 +20,8 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
     while off < len(data):
         tag = data[off:off+1]
         if tag == b"P":
-            off += 21
-            seen[tag] = 16
+            off += 5 + 8 + _perl_nv_size()
+            seen[tag] = 8 + _perl_nv_size()
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         seen[tag] = length

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -4,6 +4,7 @@ import subprocess
 import struct
 from pathlib import Path
 from tests.conftest import get_chunk_start
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_callgraph_py(tmp_path):
@@ -21,11 +22,11 @@ def test_callgraph_py(tmp_path):
     )
     data = out.read_bytes()
     start = get_chunk_start(data)
-    off = start + 21
+    off = start + 5 + 8 + _perl_nv_size()
     d_pos = data.index(b"D", off)
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
     assert d_len >= 1
-    c_pos = data.index(b"C", d_pos)
+    c_pos = d_pos + 5 + d_len
     c_len = struct.unpack_from("<I", data, c_pos + 1)[0]
     rec_size = struct.calcsize("<IIIQQ")
     assert c_len % rec_size == 0

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_dchunk_binary(tmp_path):
@@ -24,7 +25,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P record
+    idx += 5 + 8 + _perl_nv_size()  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
     assert data[idx : idx + 1] == b'D'

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_D_chunk_contains_records(tmp_path):
@@ -15,7 +16,7 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21
+    idx += 5 + 8 + _perl_nv_size()
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
     assert data[idx:idx+1]==b'D'

--- a/tests/test_debug_chunk_summary.py
+++ b/tests/test_debug_chunk_summary.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_debug_chunk_summary(tmp_path):
@@ -15,4 +16,5 @@ def test_debug_chunk_summary(tmp_path):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'DEBUG: wrote raw P record (21 B)' in proc.stderr
+    expected = f"DEBUG: wrote raw P record ({5 + 8 + _perl_nv_size()} B)"
+    assert expected in proc.stderr

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -1,4 +1,5 @@
 import subprocess, sys, struct, os, tempfile, pathlib
+from pynytprof._pywrite import _perl_nv_size
 
 def test_exactly_one_p_record(tmp_path):
     out = tmp_path/"nytprof.out"
@@ -23,4 +24,4 @@ def test_exactly_one_p_record(tmp_path):
     pid_bytes = data[idx+5:idx+9]
     assert pid_bytes == p.pid.to_bytes(4, 'little')
     s_off = data.index(b'S')
-    assert s_off == idx + 21
+    assert s_off == idx + 5 + 8 + _perl_nv_size()

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_D_payload_free_of_newlines(tmp_path):
@@ -16,7 +17,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P
+    idx += 5 + 8 + _perl_nv_size()  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_S_payload_free_of_newlines(tmp_path):
@@ -16,7 +17,7 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P
+    idx += 5 + 8 + _perl_nv_size()  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_nytprof_roundtrip.py
+++ b/tests/test_nytprof_roundtrip.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import shutil
+import pytest
+
+
+@pytest.mark.xfail(reason="roundtrip fails until NV size fix")
+def test_nytprof_roundtrip(tmp_path):
+    script = Path(__file__).with_name("example_script.py")
+    out_file = tmp_path / "nytprof.out"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    res = subprocess.run(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out_file), str(script)],
+        cwd=tmp_path,
+        env=env,
+    )
+    assert res.returncode == 0
+    if not shutil.which("perl"):
+        pytest.skip("perl missing")
+    perl = subprocess.run(
+        [
+            "perl",
+            "-MDevel::NYTProf::Data",
+            "-e",
+            "Devel::NYTProf::Data->new({filename=>$ARGV[0], quiet=>1})",
+            str(out_file),
+        ],
+        cwd=tmp_path,
+    )
+    assert perl.returncode == 0
+

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -2,8 +2,10 @@ import os
 from pathlib import Path
 import importlib.util
 import struct
+import time
 import pytest
 from pynytprof import tracer
+from pynytprof._pywrite import _perl_nv_size
 
 
 @pytest.mark.parametrize("writer", ["py"])
@@ -24,8 +26,13 @@ def test_p_length_is_16(tmp_path, writer):
     assert data[idx:idx+1] == b"P"
     pid = int.from_bytes(data[idx+5:idx+9], "little")
     assert pid == os.getpid()
-    payload = data[idx+5:idx+21]
-    assert len(payload) == 16
-    pid2, ppid, ts = struct.unpack("<IId", payload)
+    nv_size = _perl_nv_size()
+    payload = data[idx+5:idx+5+8+nv_size]
+    assert len(payload) == 8 + nv_size
+    pid2 = int.from_bytes(payload[0:4], "little")
+    ppid = int.from_bytes(payload[4:8], "little")
+    if nv_size == 8:
+        ts = struct.unpack_from("<d", payload, 8)[0]
+        assert abs(ts - time.time()) < 1.0
     assert pid2 == os.getpid()
     assert ppid == os.getppid()

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -1,6 +1,7 @@
 import os, subprocess, sys
 from pathlib import Path
 import pytest
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_p_record_is_21_bytes(tmp_path):
@@ -16,4 +17,4 @@ def test_p_record_is_21_bytes(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx + 21 : idx + 22] == b"S"
+    assert data[idx + 5 + 8 + _perl_nv_size() : idx + 5 + 8 + _perl_nv_size() + 1] == b"S"

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -4,6 +4,7 @@ import sys
 import struct
 import time
 from pathlib import Path
+from pynytprof._pywrite import _perl_nv_size
 import pytest
 
 
@@ -22,8 +23,13 @@ def test_p_record_format(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    payload = data[idx + 5 : idx + 21]
-    pid, ppid, ts = struct.unpack("<IId", payload)
+    nv_size = _perl_nv_size()
+    payload = data[idx + 5 : idx + 5 + 8 + nv_size]
+    pid = int.from_bytes(payload[0:4], "little")
+    ppid = int.from_bytes(payload[4:8], "little")
+    if nv_size == 8:
+        ts = struct.unpack_from("<d", payload, 8)[0]
+        assert abs(ts - time.time()) < 1.0
     assert pid == p.pid
     assert ppid == os.getpid()
-    assert abs(ts - time.time()) < 1.0
+

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -1,6 +1,7 @@
 import os, subprocess, sys
 from pathlib import Path
 import pytest
+from pynytprof._pywrite import _perl_nv_size
 
 def test_p_record_length(tmp_path):
     out = tmp_path / "nytprof.out"
@@ -21,5 +22,6 @@ def test_p_record_length(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+21:idx+22] in (b"S", b"C")
+    plen = 5 + 8 + _perl_nv_size()
+    assert data[idx + plen : idx + plen + 1] in (b"S", b"C")
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 import pytest
+from pynytprof._pywrite import _perl_nv_size
 
 
 def test_p_record_raw(tmp_path):
@@ -24,4 +25,4 @@ def test_p_record_raw(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+21:idx+22] == b"S"
+    assert data[idx + 5 + 8 + _perl_nv_size() : idx + 5 + 8 + _perl_nv_size() + 1] == b"S"

--- a/tests/test_writer_p_chunk.py
+++ b/tests/test_writer_p_chunk.py
@@ -4,15 +4,17 @@ import struct
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from pynytprof._pywrite import Writer
+from pynytprof._pywrite import Writer, _perl_nv_size
 
 
 def test_p_chunk_includes_length_field():
     buf = io.BytesIO()
     w = Writer(fp=buf)
-    payload = b'ABCDEFGH'
-    w._write_raw_P(payload)
+    w._write_raw_P(123, 456)
     data = buf.getvalue()
+    plen = 8 + _perl_nv_size()
     assert data[0:1] == b'P'
-    assert data[1:5] == struct.pack('<I', len(payload))
-    assert data[5:] == payload
+    assert data[1:5] == struct.pack('<I', plen)
+    assert data[5:9] == struct.pack('<I', 123)
+    assert data[9:13] == struct.pack('<I', 456)
+    assert len(data) == 5 + plen


### PR DESCRIPTION
## Summary
- add _perl_nv_size helper to query Perl `Config{nvsize}`
- use detected NV size in banner and P chunk
- update Python writer fallback accordingly
- adjust chunk offsets for variable NV sizes
- add failing round-trip test and update tests for dynamic NV

## Testing
- `pip install -e .`
- `pip install pytest-xdist`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68751d8938c48331a0336eed7268b2f2