### PR TITLE
Fix P chunk bytes and offset calculations

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -111,8 +111,10 @@ class Writer:
 
         pid = os.getpid()
         ppid = os.getppid()
-        start_time_s = time.time()
-        payload = struct.pack("<II", pid, ppid) + struct.pack("<d", start_time_s)
+        pid_bytes = struct.pack("<I", pid)
+        ppid_bytes = struct.pack("<I", ppid)
+        nv_bytes = struct.pack("<d", time.time())
+        payload = pid_bytes + ppid_bytes + nv_bytes
         assert len(payload) == 16
         banner_len = len(banner)
         self.header_size = banner_len + 1 + 4 + len(payload)
@@ -244,8 +246,10 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
 
         pid = os.getpid()
         ppid = os.getppid()
-        ts = time.time()
-        payload = struct.pack("<II", pid, ppid) + struct.pack("<d", ts)
+        pid_bytes = struct.pack("<I", pid)
+        ppid_bytes = struct.pack("<I", ppid)
+        nv_bytes = struct.pack("<d", time.time())
+        payload = pid_bytes + ppid_bytes + nv_bytes
         assert len(payload) == 16
         f.write(b"P")
         f.write(struct.pack("<I", len(payload)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def parse_chunks(data: bytes) -> dict:
                 idx += 1
                 continue
             payload = data[idx + 5 : idx + 5 + length]
-            off = idx - 1 if idx > 0 and data[idx - 1:idx] == b"\n" else idx
+            off = idx
             chunks[tag.decode()] = {
                 "offset": off,
                 "length": length,

--- a/tests/test_s_offset_after_p.py
+++ b/tests/test_s_offset_after_p.py
@@ -26,4 +26,5 @@ def test_s_offset_after_p(tmp_path):
     assert 'P' in chunks and 'S' in chunks
     p_chunk = chunks['P']
     s_chunk = chunks['S']
-    assert s_chunk['offset'] > p_chunk['offset'] + 5 + p_chunk['length']
+    expected = p_chunk['offset'] + 1 + 4 + p_chunk['length']
+    assert s_chunk['offset'] == expected


### PR DESCRIPTION
## Summary
- pack pid/ppid/time explicitly in `_pywrite.py`
- simplify `parse_chunks` offset logic
- expect exact S offset after P in tests

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68752518709c8331b6a524982ac6ac77