### PR TITLE
Fix missing PYTHONPATH in new buffer test

### DIFF
--- a/tests/test_no_buffer_chunk_P.py
+++ b/tests/test_no_buffer_chunk_P.py
@@ -1,0 +1,16 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_no_buffered_p(tmp_path):
+    out = tmp_path / 'nytprof.out'
+    env = {
+        **os.environ,
+        'PYNYTPROF_DEBUG': '1',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    logs = subprocess.check_output(
+        [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), '-e', 'pass'],
+        env=env, stderr=subprocess.STDOUT
+    ).decode()
+    assert 'buffering chunk tag=P' not in logs


### PR DESCRIPTION
## Summary
- add regression test ensuring P chunks are never buffered

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68752af31234833185daa42da7e9d475