### PR TITLE
Remove length field from P chunk

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,22 @@ def get_chunk_start(data):
 def parse_chunks(data: bytes) -> dict:
     chunks = {}
     idx = 0
-    while idx + 5 <= len(data):
+    while idx < len(data):
         tag = data[idx : idx + 1]
         if tag in b"PDSCE":
+            if tag == b"P":
+                length = 16
+                if idx + 1 + length > len(data):
+                    break
+                payload = data[idx + 1 : idx + 1 + length]
+                off = idx
+                chunks[tag.decode()] = {
+                    "offset": off,
+                    "length": length,
+                    "payload": payload,
+                }
+                idx += 1 + length
+                continue
             length = int.from_bytes(data[idx + 1 : idx + 5], "little")
             if idx + 5 + length > len(data):
                 idx += 1

--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -19,7 +19,7 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
     while off < len(data):
         tag = data[off:off+1]
         if tag == b"P":
-            off += 21
+            off += 17
             seen[tag] = 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
@@ -27,4 +27,5 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
         off += 5 + length
     assert seen[b"S"] > 0, f"S length {seen[b'S']}"
     assert seen[b"D"] > 0, f"D length {seen[b'D']}"
+
 

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -16,9 +16,10 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length
     assert b'S' in tags, f"S chunk missing, only saw {tags!r}"
     assert b'D' in tags, f"D chunk missing, only saw {tags!r}"
+

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -21,7 +21,7 @@ def test_callgraph_py(tmp_path):
     )
     data = out.read_bytes()
     start = get_chunk_start(data)
-    off = start + 21
+    off = start + 17
     d_pos = data.index(b"D", off)
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
     assert d_len >= 1
@@ -29,3 +29,4 @@ def test_callgraph_py(tmp_path):
     c_len = struct.unpack_from("<I", data, c_pos + 1)[0]
     rec_size = struct.calcsize("<IIIQQ")
     assert c_len % rec_size == 0
+

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -16,8 +16,9 @@ def test_c_writer_emits_C_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert b"C" in tokens
+

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -15,8 +15,9 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[3] == b'C'
+

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -16,8 +16,9 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[3] == b'C'
+

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -16,8 +16,9 @@ def test_c_writer_emits_D_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert b"D" in tokens
+

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -15,8 +15,9 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[2] == b'D'
+

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -16,8 +16,9 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[2] == b'D'
+

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -15,9 +15,10 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
     assert tokens == [b'P', b'S', b'D', b'C', b'E']
+

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -16,9 +16,10 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
     assert tokens == [b'P', b'S', b'D', b'C', b'E']
+

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -15,8 +15,9 @@ def test_c_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[1] == b'S'
+

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -16,8 +16,9 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[1] == b'S'
+

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -21,10 +21,11 @@ def test_c_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
     assert tokens == [b'P', b'S', b'D', b'C', b'E']
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
+

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -21,8 +21,9 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length
     assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Got {tags!r}"
+

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -21,10 +21,11 @@ def test_py_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length
     assert tokens == [b"P", b"S", b"D", b"C", b"E"]
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
+

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -23,8 +23,9 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         tok = data[off : off + 1]
         tags.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
     assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Got {tags!r}"
+

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -16,8 +16,9 @@ def test_c_writer_chunk_sequence(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
     assert tokens == [b'P', b'S', b'D', b'C', b'E']
+

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -24,7 +24,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P record
+    idx += 17  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
     assert data[idx : idx + 1] == b'D'
@@ -33,3 +33,4 @@ def test_dchunk_binary(tmp_path):
     assert payload.startswith(b"\x01")
     assert payload.endswith(b"\x00")
     assert dlen > 1
+

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -15,9 +15,10 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21
+    idx += 17
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
     assert data[idx:idx+1]==b'D'
     dlen = int.from_bytes(data[idx+1:idx+5],'little')
     assert dlen > 1, f"D chunk too small ({dlen}); no records collected"
+

--- a/tests/test_debug_chunk_summary.py
+++ b/tests/test_debug_chunk_summary.py
@@ -15,4 +15,5 @@ def test_debug_chunk_summary(tmp_path):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'DEBUG: wrote raw P record (21 B)' in proc.stderr
+    assert 'DEBUG: wrote raw P record (17 B)' in proc.stderr
+

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -20,7 +20,8 @@ def test_exactly_one_p_record(tmp_path):
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
     assert data[idx:idx+1] == b'P'
-    pid_bytes = data[idx+5:idx+9]
+    pid_bytes = data[idx+1:idx+5]
     assert pid_bytes == p.pid.to_bytes(4, 'little')
     s_off = data.index(b'S')
-    assert s_off == idx + 21
+    assert s_off == idx + 17
+

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -14,7 +14,7 @@ def _tokens(out):
         tok = data[off:off+1]
         toks.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
@@ -36,3 +36,4 @@ def test_full_sequence_c(tmp_path, monkeypatch):
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), SCRIPT])
     assert _tokens(out) == b'PSDCE'
+

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -14,5 +14,6 @@ def test_no_buffer_chunk_for_p(tmp_path):
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
     pid_bytes = os.getpid().to_bytes(4, "little")
-    assert data[idx+5:idx+9] == pid_bytes
+    assert data[idx+1:idx+5] == pid_bytes
     assert data.count(b"\nP") == 1
+

--- a/tests/test_no_newline_bytes_after_header.py
+++ b/tests/test_no_newline_bytes_after_header.py
@@ -13,8 +13,9 @@ def test_no_newline_bytes_after_header(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    split = data.index(b'\nP') + 1 + 1 + 4 + 4 + 4 + 8
+    split = data.index(b'\nP') + 1 + 1 + 4 + 4 + 8
     tail = data[split:]
     # Assert no 0x0A anywhere in the binary section
     pos = tail.find(b'\n')
     assert pos == -1, f"Found newline in payload at offset {split + pos}"
+

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -16,7 +16,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P
+    idx += 17  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen
@@ -25,3 +25,4 @@ def test_D_payload_free_of_newlines(tmp_path):
     dlen = int.from_bytes(data[idx+1:idx+5],'little')
     dpayload = data[idx+5:idx+5+dlen]
     assert dpayload.endswith(b"\x00")
+

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -16,9 +16,10 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = data.index(b'\nP') + 1
-    idx += 21  # skip P
+    idx += 17  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     spayload = data[idx+5:idx+5+slen]
     assert b'\n' not in spayload, "S payload contains newline"
+

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -29,9 +29,10 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         tag = data[off : off + 1]
         tags.append(tag)
         if tag == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
 
     assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"
+

--- a/tests/test_p_chunk_size.py
+++ b/tests/test_p_chunk_size.py
@@ -1,0 +1,13 @@
+import io, struct
+from pynytprof._pywrite import Writer
+
+def test_p_chunk_is_17_bytes():
+    buf = io.BytesIO()
+    w = Writer(fp=buf)
+    w._write_raw_P()
+    data = buf.getvalue()
+    assert data[:1] == b'P'
+    assert len(data) == 17, (
+        f'P record should be 17 bytes (tag+payload), got {len(data)}'
+    )
+

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -22,10 +22,11 @@ def test_p_length_is_16(tmp_path, writer):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    pid = int.from_bytes(data[idx+5:idx+9], "little")
+    pid = int.from_bytes(data[idx+1:idx+5], "little")
     assert pid == os.getpid()
-    payload = data[idx+5:idx+21]
+    payload = data[idx+1:idx+17]
     assert len(payload) == 16
     pid2, ppid, ts = struct.unpack("<IId", payload)
     assert pid2 == os.getpid()
     assert ppid == os.getppid()
+

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 
-def test_p_record_is_21_bytes(tmp_path):
+def test_p_record_is_17_bytes(tmp_path):
     out = tmp_path / "nytprof.out"
     env = {
         **os.environ,
@@ -16,4 +16,5 @@ def test_p_record_is_21_bytes(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx + 21 : idx + 22] == b"S"
+    assert data[idx + 17 : idx + 18] == b"S"
+

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -22,8 +22,9 @@ def test_p_record_format(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    payload = data[idx + 5 : idx + 21]
+    payload = data[idx + 1 : idx + 17]
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == p.pid
     assert ppid == os.getpid()
     assert abs(ts - time.time()) < 1.0
+

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -21,5 +21,6 @@ def test_p_record_length(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+21:idx+22] in (b"S", b"C")
+    assert data[idx+17:idx+18] in (b"S", b"C")
+
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -24,4 +24,5 @@ def test_p_record_raw(tmp_path):
     data = out.read_bytes()
     idx = data.index(b"\nP") + 1
     assert data[idx:idx+1] == b"P"
-    assert data[idx+21:idx+22] == b"S"
+    assert data[idx+17:idx+18] == b"S"
+

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -23,7 +23,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         tag = data[off:off+1]
         tags.append(tag)
         if tag == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             seen[tag] = seen.get(tag, 0) + 1
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
@@ -33,3 +33,4 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
     assert seen[b'P'] == 1 and seen[b'S'] == 1 and seen[b'D'] == 1 and seen[b'C'] == 1 and seen[b'E'] == 1
     assert all(seen[t] == 1 for t in tags)
     assert all(l > 0 for t, l in seen.items() if t != b'E')
+

--- a/tests/test_s_offset_after_p.py
+++ b/tests/test_s_offset_after_p.py
@@ -26,5 +26,5 @@ def test_s_offset_after_p(tmp_path):
     assert 'P' in chunks and 'S' in chunks
     p_chunk = chunks['P']
     s_chunk = chunks['S']
-    expected = p_chunk['offset'] + 1 + 4 + p_chunk['length']
+    expected = p_chunk['offset'] + 1 + p_chunk['length']
     assert s_chunk['offset'] == expected

--- a/tests/test_s_offset_matches_p_length.py
+++ b/tests/test_s_offset_matches_p_length.py
@@ -23,5 +23,5 @@ def test_s_offset_matches_p_chunk_length(tmp_path):
     p_off = chunks['P']['offset']
     p_len = chunks['P']['length']
     s_off = chunks['S']['offset']
-    expected = p_off + 1 + 4 + p_len
+    expected = p_off + 1 + p_len
     assert s_off == expected, f"S offset {s_off:#x} != expected {expected:#x}"

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -27,7 +27,7 @@ def test_schunk(tmp_path, writer):
         tok = chunks[off : off + 1]
         tokens.append(tok)
         if tok == b"P":
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(chunks[off + 1 : off + 5], "little")
         if tok == b"S":
@@ -37,3 +37,4 @@ def test_schunk(tmp_path, writer):
     assert s_off is not None
     slen = int.from_bytes(chunks[s_off + 1 : s_off + 5], "little")
     assert slen % 28 == 0 and slen > 0
+

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -17,9 +17,10 @@ def test_one_F_chunk(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 1 + 4 + 4 + 4 + 8
+            off += 1 + 4 + 4 + 8
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     f_positions = [i for i, t in enumerate(tags) if t == b'F']
     assert f_positions == [], f'Unexpected F chunk positions: {f_positions}'
+

--- a/tests/test_writer_p_chunk.py
+++ b/tests/test_writer_p_chunk.py
@@ -1,18 +1,16 @@
 from pathlib import Path
 import io
-import struct
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from pynytprof._pywrite import Writer
 
 
-def test_p_chunk_includes_length_field():
+def test_p_chunk_is_17_bytes_writer():
     buf = io.BytesIO()
     w = Writer(fp=buf)
-    payload = b'ABCDEFGH'
-    w._write_raw_P(payload)
+    w._write_raw_P()
     data = buf.getvalue()
     assert data[0:1] == b'P'
-    assert data[1:5] == struct.pack('<I', len(payload))
-    assert data[5:] == payload
+    assert len(data) == 17
+


### PR DESCRIPTION
## Summary
- drop 4-byte length from the process start chunk
- adapt header bookkeeping for the 17 byte `P` record
- fix helper to parse P chunks in tests
- update tests for new layout
- add regression test for exact P size

## Testing
- `pytest -n auto`
- `nytprofhtml -f nytprof.out -o report` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_687534f353448331b9448c0fe6975067