### PR TITLE
Fix P-chunk format and add PID check

### DIFF
--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -36,7 +36,7 @@ NYTProf <major> <minor>\n
 Most records are **TLV** → `tag:u8` + `len:u32(le)` + `payload`.
 
 **Sequence**
-1. `P`  process-start (21 bytes total)
+1. `P`  process-start (17 bytes total)
 2. `S`  statement samples
 3. `D`  sub-descriptors
 4. `C`  call-graph edges
@@ -44,7 +44,7 @@ Most records are **TLV** → `tag:u8` + `len:u32(le)` + `payload`.
 
 | Tag | Size field | Payload struct (little-endian)                                      | Notes                                               |
 |-----|------------|---------------------------------------------------------------------|-----------------------------------------------------|
-| `P` | yes | `u32 pid, u32 ppid, double start_time_sec` | TLV: tag `P` (0x50) + `u32 length_le = 16` + payload |
+| `P` | no  | `u32 pid, u32 ppid, double start_time_sec` | tag `P` (0x50) immediately followed by 16-byte payload |
 | `S` | yes        | `u32 fid, u32 line, u32 calls, u64 inc_ticks, u64 exc_ticks` × M   | 100 ns ticks                                       |
 | `D` | yes        | `u32 sid, u32 flags, zstr name` × K                                | flags=0 for now                                    |
 | `C` | yes        | `u32 caller_sid, u32 callee_sid, u32 calls, u64 ticks, u64 sub_ticks` × L | Call-graph edges                                  |

--- a/tests/test_p_chunk_pid.py
+++ b/tests/test_p_chunk_pid.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_p_chunk_pid_matches_process(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    p = subprocess.Popen(
+        [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"],
+        env=env,
+    )
+    p.wait()
+    data = out.read_bytes()
+    idx = data.index(b"\nP") + 1
+    assert data[idx : idx + 1] == b"P"
+    pid_le = int.from_bytes(data[idx + 1 : idx + 5], "little")
+    assert pid_le == p.pid, f"P-chunk PID {pid_le} != subprocess pid {p.pid}"


### PR DESCRIPTION
## Summary
- update docs for new P-chunk layout (no length field)
- add unit test checking process PID inside P chunk

## Testing
- `pytest -n auto`
- `nytprofhtml nytprof.out` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_68753c756b948331a7f6cd9293babb8d