### PR TITLE
Fix header newline and raw P record

### DIFF
--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -10,7 +10,8 @@ layered later.
 1  ASCII banner (text header)
 ──────────────────────────────────────────────────────────────────────
 
-Each line ends in a single `\n` — **no blank line is inserted**. Format:
+Each line ends in a single `\n`. A blank line follows the banner before the
+binary stream begins. Format:
 
 ```text
 NYTProf <major> <minor>\n

--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -121,6 +121,7 @@ class Writer:
             print(f"DEBUG: writing banner len={len(banner)}", file=sys.stderr)
             print(f"DEBUG: banner_end={last_line!r}", file=sys.stderr)
         self._fh.write(banner)
+        self._fh.write(b"\n")
 
         pid = os.getpid()
         ppid = os.getppid()
@@ -132,9 +133,9 @@ class Writer:
         )
         assert len(payload) == 16
         banner_len = len(banner)
-        self.header_size = banner_len + 17
+        self.header_size = banner_len + 1 + 17
         if os.getenv("PYNYTPROF_DEBUG"):
-            p_offset = banner_len
+            p_offset = banner_len + 1
             s_offset = p_offset + 17
             print(f"DEBUG: P-payload raw={payload.hex()}", file=sys.stderr)
             print(
@@ -261,6 +262,7 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
     with path.open("wb") as f:
         banner = _make_ascii_header(start_ns)
         f.write(banner)
+        f.write(b"\n")
 
         pid = os.getpid()
         ppid = os.getppid()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 def get_chunk_start(data):
-    cutoff = data.index(b"\nP") + 1
+    cutoff = data.index(b"\n\nP") + 2
     return cutoff
 
 

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -9,7 +9,7 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     tags=[]
     off=idx
     while off < len(data):

--- a/tests/test_banner_ends_and_first_tag_is_P.py
+++ b/tests/test_banner_ends_and_first_tag_is_P.py
@@ -18,5 +18,5 @@ def test_banner_ends_and_first_tag_is_P(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\nP')
-    assert data[idx:idx+2] == b"\nP"
+    idx = data.index(b'\n\nP')
+    assert data[idx:idx+3] == b"\n\nP"

--- a/tests/test_banner_exact_termination.py
+++ b/tests/test_banner_exact_termination.py
@@ -16,7 +16,7 @@ def test_banner_ends_with_single_newline(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.find(b"\nP")
-    assert idx != -1, "Did not find \\nP"
-    next_bytes = data[idx:idx+2]
-    assert next_bytes == b"\nP", f"Expected exactly '\\nP', got {next_bytes}"
+    idx = data.find(b"\n\nP")
+    assert idx != -1, "Did not find \\n\nP"
+    next_bytes = data[idx:idx+3]
+    assert next_bytes == b"\n\nP", f"Expected exactly '\\n\nP', got {next_bytes}"

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -9,7 +9,7 @@ def test_c_writer_emits_C_chunk(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\nP") + 1
+    cutoff = data.index(b"\n\nP") + 2
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -9,7 +9,7 @@ def test_c_writer_emits_D_chunk(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\nP") + 1
+    cutoff = data.index(b"\n\nP") + 2
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -14,7 +14,7 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         'tests/example_script.py'
     ])
     data = out.read_bytes()
-    cutoff = data.index(b'\nP') + 1
+    cutoff = data.index(b'\n\nP') + 2
     tags = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -13,7 +13,7 @@ def test_py_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    end = data.index(b"\nP") + 1
+    end = data.index(b"\n\nP") + 2
     chunks = data[end:]
     tokens = []
     off = 0

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -16,7 +16,7 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     tags = []
     off = idx
     while off < len(data):

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -9,7 +9,7 @@ def test_c_writer_chunk_sequence(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\nP") + 1
+    cutoff = data.index(b"\n\nP") + 2
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -23,7 +23,7 @@ def test_dchunk_binary(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     idx += 17  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -14,7 +14,7 @@ def test_D_chunk_contains_records(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     idx += 17
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -18,7 +18,7 @@ def test_exactly_one_p_record(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     assert data[idx:idx+1] == b'P'
     pid_bytes = data[idx+1:idx+5]
     assert pid_bytes == p.pid.to_bytes(4, 'little')

--- a/tests/test_header_newline_and_p_tag.py
+++ b/tests/test_header_newline_and_p_tag.py
@@ -1,0 +1,25 @@
+import os, subprocess, sys
+from pathlib import Path
+
+
+def test_exactly_two_lf_before_p(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {**os.environ,
+           "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")}
+    p = subprocess.Popen([sys.executable, "-m", "pynytprof.tracer",
+                          "-o", str(out), "-e", "pass"], env=env)
+    p.wait()
+    data = out.read_bytes()
+    idx_p = data.index(b'\n\nP') + 2  # start of raw P record
+    # Count consecutive LF bytes immediately before 'P'
+    lf_count = 0
+    i = idx_p - 1
+    while data[i] == 0x0A:
+        lf_count += 1
+        i -= 1
+    assert lf_count == 2, (
+        f"expected exactly 2 LF before 'P', found {lf_count}"
+    )
+    # First 4 payload bytes must be the real PID, not length=16
+    pid = int.from_bytes(data[idx_p+1:idx_p+5], 'little')
+    assert pid == p.pid, "still writing length word after 'P'"

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -11,9 +11,9 @@ def test_no_buffer_chunk_for_p(tmp_path):
     with Writer(str(out)):
         pass
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     pid_bytes = os.getpid().to_bytes(4, "little")
     assert data[idx+1:idx+5] == pid_bytes
-    assert data.count(b"\nP") == 1
+    assert data.count(b"\n\nP") == 1
 

--- a/tests/test_no_extra_newline_before_first_chunk.py
+++ b/tests/test_no_extra_newline_before_first_chunk.py
@@ -20,6 +20,6 @@ def test_no_extra_newline_before_first_chunk(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\nP')
-    assert data[idx+1:idx+2] == b'P', f"Found {data[idx+1:idx+2]!r} before first chunk"
+    idx = data.index(b'\n\nP')
+    assert data[idx+2:idx+3] == b'P', f"Found {data[idx+2:idx+3]!r} before first chunk"
 

--- a/tests/test_no_newline_bytes_after_header.py
+++ b/tests/test_no_newline_bytes_after_header.py
@@ -13,7 +13,7 @@ def test_no_newline_bytes_after_header(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    split = data.index(b'\nP') + 1 + 1 + 4 + 4 + 8
+    split = data.index(b'\n\nP') + 2 + 1 + 4 + 4 + 8
     tail = data[split:]
     # Assert no 0x0A anywhere in the binary section
     pos = tail.find(b'\n')

--- a/tests/test_no_newlines_after_chunks.py
+++ b/tests/test_no_newlines_after_chunks.py
@@ -17,7 +17,7 @@ def test_no_newlines_after_chunks(tmp_path, monkeypatch):
         'tests/example_script.py',
     ], env=env)
     data = out.read_bytes()
-    off = data.index(b'\nP') + 1
+    off = data.index(b'\n\nP') + 2
     while off < len(data):
         length = int.from_bytes(data[off + 1:off + 5], 'little')
         end = off + 5 + length

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -15,7 +15,7 @@ def test_D_payload_free_of_newlines(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     idx += 17  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -15,7 +15,7 @@ def test_S_payload_free_of_newlines(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     idx += 17  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -22,7 +22,7 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         env=os.environ,
     )
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     tags = []
     off = idx
     while off < len(data):

--- a/tests/test_only_one_lf_before_P.py
+++ b/tests/test_only_one_lf_before_P.py
@@ -17,6 +17,6 @@ def test_only_one_lf_before_P(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    i = data.index(b'\nP')
-    assert data[i:i+2] == b'\nP'
-    assert i == data.index(b'\nP')  # ensure no earlier instance
+    i = data.index(b'\n\nP')
+    assert data[i:i+3] == b'\n\nP'
+    assert i == data.index(b'\n\nP')  # ensure no earlier instance

--- a/tests/test_p_chunk_layout.py
+++ b/tests/test_p_chunk_layout.py
@@ -22,7 +22,7 @@ def test_p_chunk_has_no_length_word(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     pid = int.from_bytes(data[idx + 1 : idx + 5], "little")
     assert pid == p.pid, (
         "Found length word instead of PID — P chunk layout is wrong"

--- a/tests/test_p_chunk_pid.py
+++ b/tests/test_p_chunk_pid.py
@@ -16,7 +16,7 @@ def test_p_chunk_pid_matches_process(tmp_path):
     )
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx : idx + 1] == b"P"
     pid_le = int.from_bytes(data[idx + 1 : idx + 5], "little")
     assert pid_le == p.pid, f"P-chunk PID {pid_le} != subprocess pid {p.pid}"

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -20,7 +20,7 @@ def test_p_length_is_16(tmp_path, writer):
     tracer.profile_command("pass", out_path=out)
     monkeypatch.undo()
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     pid = int.from_bytes(data[idx+1:idx+5], "little")
     assert pid == os.getpid()

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -14,7 +14,7 @@ def test_p_record_is_17_bytes(tmp_path):
         [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env
     )
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     assert data[idx + 17 : idx + 18] == b"S"
 

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -20,7 +20,7 @@ def test_p_record_format(tmp_path):
     )
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     payload = data[idx + 1 : idx + 17]
     pid, ppid, ts = struct.unpack("<IId", payload)

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -19,7 +19,7 @@ def test_p_record_length(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     assert data[idx+17:idx+18] in (b"S", b"C")
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -22,7 +22,7 @@ def test_p_record_raw(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\nP") + 1
+    idx = data.index(b"\n\nP") + 2
     assert data[idx:idx+1] == b"P"
     assert data[idx+17:idx+18] == b"S"
 

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -15,7 +15,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         env=env, stderr=subprocess.PIPE, text=True
     )
     data = out.read_bytes()
-    idx = data.index(b'\nP') + 1
+    idx = data.index(b'\n\nP') + 2
     tags = []
     seen = {}
     off = idx

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -18,7 +18,7 @@ def test_schunk(tmp_path, writer):
         env=env,
     )
     data = out.read_bytes()
-    end = data.index(b"\nP") + 1
+    end = data.index(b"\n\nP") + 2
     chunks = data[end:]
     tokens = []
     off = 0

--- a/tests/test_single_lf_before_p.py
+++ b/tests/test_single_lf_before_p.py
@@ -19,7 +19,7 @@ def test_single_lf_before_p(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\nP')
-    assert data[idx:idx+2] == b'\nP'
-    assert b'\n\nP' not in data
+    idx = data.index(b'\n\nP')
+    assert data[idx:idx+3] == b'\n\nP'
+    assert b'\n\n\nP' not in data
 

--- a/tests/test_single_p_chunk_only.py
+++ b/tests/test_single_p_chunk_only.py
@@ -19,7 +19,7 @@ def test_only_one_p_record_and_no_length(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    positions = [i + 1 for i in range(len(data)) if data[i:i+2] == b"\nP"]
+    positions = [i + 2 for i in range(len(data)) if data[i:i+3] == b"\n\nP"]
     assert len(positions) == 1, f"expected 1 P chunk, found {len(positions)}"
     idx = positions[0]
     pid = int.from_bytes(data[idx+1:idx+5], "little")


### PR DESCRIPTION
## Summary
- ensure banner is followed by one blank line and write raw `P` record
- document blank line in `FILE_FORMAT.md`
- adjust tests for new header layout
- add regression test for newline count before `P`

## Testing
- `pytest -n auto -q`
- `nytprofhtml --version`

------
https://chatgpt.com/codex/tasks/task_e_6875f6b5fd588331b2285f646ab51d3e