### PR TITLE
Fix header newline handling

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -123,6 +123,7 @@ static void store_le_double(FILE *fp, double v) {
 
 static void emit_header(FILE *fp) {
     emit_banner(fp);
+    fputc('\n', fp);
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     double t = (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;

--- a/tests/test_header_blank_lines.py
+++ b/tests/test_header_blank_lines.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_exact_two_newlines_before_P(tmp_path):
+    out = tmp_path / "nytprof.out"
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    p = subprocess.Popen([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        "-o",
+        str(out),
+        "-e",
+        "pass",
+    ], env=env)
+    p.wait()
+    data = out.read_bytes()
+    idx = data.index(b"\n\nP") + 2
+    count = 0
+    i = idx - 1
+    while i >= 0 and data[i] == 0x0A:
+        count += 1
+        i -= 1
+    assert count == 2, f"Expected 2 blank lines before P, found {count}"


### PR DESCRIPTION
## Summary
- ensure C writer emits a blank line before the `P` chunk
- test that only two newlines precede the first binary byte

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6876012694b48331b29d65702adcb9bb