### PR TITLE
Fix P record format in C writer

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -141,7 +141,6 @@ static void emit_header(FILE *fp) {
     clock_gettime(CLOCK_REALTIME, &ts);
     double t = (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
     fputc('P', fp);
-    store_le32(fp, 16); /* payload length */
     store_le32(fp, (uint32_t)getpid());
     store_le32(fp, (uint32_t)getppid());
     store_le_double(fp, t);


### PR DESCRIPTION
## Summary
- remove the stray length field from the C writer's P record

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68762a263fbc8331b248c547cb3ca0a1