### PR TITLE
Fix header_size spec

### DIFF
--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -99,9 +99,9 @@ static unsigned emit_banner(FILE *fp) {
                        "!evals=0\n",
                        NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
                        PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
-    unsigned header_size = (unsigned)len + (unsigned)strlen(":header_size=00000\n") + 1;
-    fprintf(fp, "%s:header_size=%05u\n\n", buf, header_size);
-    return header_size;
+    unsigned size = strlen(buf) + 18;            /* bytes before blank line */
+    fprintf(fp, "%s:header_size=%05u\n\n", buf, size);
+    return size;
 }
 
 static void put_double_le(unsigned char *p, double v) {

--- a/tests/test_header_size_and_no_placeholder.py
+++ b/tests/test_header_size_and_no_placeholder.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def test_header_size_and_no_placeholder(tmp_path):
     env = {
         **os.environ,
@@ -31,12 +32,10 @@ def test_header_size_and_no_placeholder(tmp_path):
     assert m, "Missing ':header_size=' line in banner"
     declared = int(m.group(1))
 
-    # 3) Compute actual split offset: header bytes + exactly one blank-line LF
-    #    the second LF is at index = len(header) + 1
-    actual = len(header) + 2
-    assert declared == actual, (
-        f"Declared header_size={declared} but actual split is at {actual}"
-    )
+    # 3) header_size should equal the banner length before the blank line
+    #    (i.e. byte position of first LF of the blank line)
+    actual = len(header)
+    assert declared == actual, f"Declared header_size={declared} but header length is {actual}"
 
     # 4) Sanity: first payload byte must be 'P'
     assert payload.startswith(b"P"), "Binary payload does not start with 'P' tag"

--- a/tests/test_header_size_field.py
+++ b/tests/test_header_size_field.py
@@ -2,6 +2,7 @@ import os, subprocess, sys, re
 from pathlib import Path
 import pytest
 
+
 @pytest.mark.parametrize("writer", ["py", "c"])
 def test_header_size_points_to_P(tmp_path, writer):
     out = tmp_path / "nytprof.out"
@@ -12,24 +13,26 @@ def test_header_size_points_to_P(tmp_path, writer):
     }
     if writer == "c":
         import importlib.util
+
         if importlib.util.find_spec("pynytprof._cwrite") is None:
             pytest.skip("_cwrite missing")
-    subprocess.check_call([
-        sys.executable,
-        "-m",
-        "pynytprof.tracer",
-        "-o",
-        str(out),
-        "-e",
-        "pass",
-    ], env=env)
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pynytprof.tracer",
+            "-o",
+            str(out),
+            "-e",
+            "pass",
+        ],
+        env=env,
+    )
     data = out.read_bytes()
     header, _ = data.split(b"\n\n", 1)
     header_txt = header.decode()
     m = re.search(r":header_size=(\d+)", header_txt)
     assert m, "header_size line missing"
     declared = int(m.group(1))
-    actual = len(header) + 2
-    assert declared == actual, (
-        f"header_size {declared} should equal blank-line offset {actual}"
-    )
+    actual = len(header)
+    assert declared == actual, f"header_size {declared} should equal header length {actual}"


### PR DESCRIPTION
## Summary
- update test expectations for NYTProf banner length
- compute header_size as ASCII header length
- sync C writer implementation

## Testing
- `pytest -n auto -q`
- `PYTHONPATH=src PYNYTPROF_WRITER=py python -m pynytprof.tracer tests/example_script.py` (fails: token 10 error)
- `nytprofhtml -f nytprof.out.13502` (fails: token 10 error)


------
https://chatgpt.com/codex/tasks/task_e_687774653dc48331841cf2efdb4ea6a8