### PR TITLE
Fix header_size to match P tag position

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -120,9 +120,11 @@ class Writer:
         ]
         static = "\n".join(lines) + "\n"
 
-        header_size = len(static) + 18
+        static_bytes = static.encode()
+        placeholder = b":header_size=00000\n"
+        header_size = len(static_bytes) + len(placeholder) + 1
         size_line = f":header_size={header_size:05d}\n".encode()
-        banner = static.encode() + size_line + b"\n"
+        banner = static_bytes + size_line + b"\n"
         if os.getenv("PYNYTPROF_DEBUG"):
             last_line = banner.rstrip(b"\n").split(b"\n")[-1] + b"\n"
             print(f"DEBUG: writing banner len={len(banner)}", file=sys.stderr)
@@ -291,9 +293,11 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
             "!evals=0",
         ]
         static_hdr = "\n".join(lines_hdr) + "\n"
-        header_size = len(static_hdr) + 18
+        static_bytes = static_hdr.encode()
+        placeholder = b":header_size=00000\n"
+        header_size = len(static_bytes) + len(placeholder) + 1
         size_line = f":header_size={header_size:05d}\n".encode()
-        banner = static_hdr.encode() + size_line + b"\n"
+        banner = static_bytes + size_line + b"\n"
         f.write(banner)
 
         pid = os.getpid()

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -99,9 +99,12 @@ static unsigned emit_banner(FILE *fp) {
                        "!evals=0\n",
                        NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
                        PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
-    unsigned size = strlen(buf) + 18;            /* bytes before blank line */
-    fprintf(fp, "%s:header_size=%05u\n\n", buf, size);
-    return size;
+    size_t static_len = strlen(buf);
+    unsigned header_size = static_len + strlen(":header_size=00000\n") + 1;
+    char size_line[32];
+    snprintf(size_line, sizeof size_line, ":header_size=%05u\n", header_size);
+    fprintf(fp, "%s%s\n", buf, size_line);
+    return header_size;
 }
 
 static void put_double_le(unsigned char *p, double v) {

--- a/tests/test_header_size_and_no_placeholder.py
+++ b/tests/test_header_size_and_no_placeholder.py
@@ -32,10 +32,11 @@ def test_header_size_and_no_placeholder(tmp_path):
     assert m, "Missing ':header_size=' line in banner"
     declared = int(m.group(1))
 
-    # 3) header_size should equal the banner length before the blank line
-    #    (i.e. byte position of first LF of the blank line)
-    actual = len(header)
-    assert declared == actual, f"Declared header_size={declared} but header length is {actual}"
+    # 3) header_size must equal the byte offset of the 'P' tag
+    p_offset = len(header) + 2
+    assert declared == p_offset, (
+        f"Declared header_size={declared} but first 'P' is at {p_offset}"
+    )
 
     # 4) Sanity: first payload byte must be 'P'
     assert payload.startswith(b"P"), "Binary payload does not start with 'P' tag"

--- a/tests/test_header_size_field.py
+++ b/tests/test_header_size_field.py
@@ -34,5 +34,7 @@ def test_header_size_points_to_P(tmp_path, writer):
     m = re.search(r":header_size=(\d+)", header_txt)
     assert m, "header_size line missing"
     declared = int(m.group(1))
-    actual = len(header)
-    assert declared == actual, f"header_size {declared} should equal header length {actual}"
+    p_offset = len(header) + 2
+    assert declared == p_offset, (
+        f"header_size {declared} should equal P offset {p_offset}"
+    )


### PR DESCRIPTION
## Summary
- fix header_size computation in Python and C writers so it equals the offset of
  the `P` record (accounts for the blank line)
- update tests to check header_size against the `P` offset

## Testing
- `pytest -q -n auto`
- `PYNYTPROF_WRITER=py PYTHONPATH=src python -m pynytprof.tracer tests/example_script.py`
- `nytprofhtml -f nytprof.out.*` *(fails: Profile format error)*

------
https://chatgpt.com/codex/tasks/task_e_687781313e7083319093e10dc8a8f970