### PR TITLE
Fix header_size calculation and tests

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -118,13 +118,13 @@ class Writer:
             "!calls=1",
             "!evals=0",
         ]
-        static = "\n".join(lines) + "\n"
+        static_banner = "\n".join(lines) + "\n"
 
-        static_bytes = static.encode()
-        placeholder = b":header_size=00000\n"
-        header_size = len(static_bytes) + len(placeholder) + 1
+        static_bytes = static_banner.encode()
+        size_line_placeholder = b":header_size=00000\n"
+        header_size = len(static_bytes) + len(size_line_placeholder)
         size_line = f":header_size={header_size:05d}\n".encode()
-        banner = static_bytes + size_line + b"\n"
+        banner = static_bytes + size_line
         if os.getenv("PYNYTPROF_DEBUG"):
             last_line = banner.rstrip(b"\n").split(b"\n")[-1] + b"\n"
             print(f"DEBUG: writing banner len={len(banner)}", file=sys.stderr)
@@ -132,6 +132,9 @@ class Writer:
 
         self._fh.write(banner)
         self._offset += len(banner)
+
+        self._fh.write(b"\n")
+        self._offset += 1
 
         self._write_raw_P()
         if os.getenv("PYNYTPROF_DEBUG"):
@@ -295,10 +298,11 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
         static_hdr = "\n".join(lines_hdr) + "\n"
         static_bytes = static_hdr.encode()
         placeholder = b":header_size=00000\n"
-        header_size = len(static_bytes) + len(placeholder) + 1
+        header_size = len(static_bytes) + len(placeholder)
         size_line = f":header_size={header_size:05d}\n".encode()
-        banner = static_bytes + size_line + b"\n"
+        banner = static_bytes + size_line
         f.write(banner)
+        f.write(b"\n")
 
         pid = os.getpid()
         ppid = os.getppid()

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -99,12 +99,10 @@ static unsigned emit_banner(FILE *fp) {
                        "!evals=0\n",
                        NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
                        PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
-    size_t static_len = strlen(buf);
-    unsigned header_size = static_len + strlen(":header_size=00000\n") + 1;
-    char size_line[32];
-    snprintf(size_line, sizeof size_line, ":header_size=%05u\n", header_size);
-    fprintf(fp, "%s%s\n", buf, size_line);
-    return header_size;
+    unsigned hdr_size = strlen(buf) + 19; /* size_line length = 19 */
+    fprintf(fp, "%s:header_size=%05u\n", buf, hdr_size);
+    fputc('\n', fp);          /* blank line not counted */
+    return hdr_size;
 }
 
 static void put_double_le(unsigned char *p, double v) {

--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -117,8 +117,9 @@ class Writer:
         ]
         static_hdr = "\n".join(hdr_lines) + "\n"
         size_of_static = len(static_hdr.encode())
-        header_size = size_of_static + len(":header_size=00000\n") + 1
+        header_size = size_of_static + len(":header_size=00000\n")
         hdr = _make_ascii_header(static_hdr, header_size)
+        hdr += b"\n"
         data = hdr
         if os.getenv("PYNYTPROF_DEBUG"):
             print(f"DEBUG: about to write raw data of length={len(data)}", file=sys.stderr)

--- a/tests/test_header_size_and_no_placeholder.py
+++ b/tests/test_header_size_and_no_placeholder.py
@@ -32,10 +32,10 @@ def test_header_size_and_no_placeholder(tmp_path):
     assert m, "Missing ':header_size=' line in banner"
     declared = int(m.group(1))
 
-    # 3) header_size must equal the byte offset of the 'P' tag
-    p_offset = len(header) + 2
-    assert declared == p_offset, (
-        f"Declared header_size={declared} but first 'P' is at {p_offset}"
+    # header returned by split() already includes the final '\n'
+    actual = len(header) + 1
+    assert declared == actual, (
+        f"header_size={declared}, but header length={actual}"
     )
 
     # 4) Sanity: first payload byte must be 'P'

--- a/tests/test_header_size_field.py
+++ b/tests/test_header_size_field.py
@@ -35,6 +35,6 @@ def test_header_size_points_to_P(tmp_path, writer):
     assert m, "header_size line missing"
     declared = int(m.group(1))
     p_offset = len(header) + 2
-    assert declared == p_offset, (
-        f"header_size {declared} should equal P offset {p_offset}"
+    assert declared + 1 == p_offset, (
+        f"header_size {declared} should equal P offset {p_offset} minus 1"
     )


### PR DESCRIPTION
## Summary
- follow NYTProf spec: exclude blank line when computing `header_size`
- adjust Python and C writers for new `header_size`
- update tests to match revised logic

## Testing
- `pytest -n auto -q`
- `PYNYTPROF_WRITER=py python -m pynytprof.tracer tests/example_script.py`
- `nytprofhtml -f nytprof.out.18322` *(fails: token error)*

------
https://chatgpt.com/codex/tasks/task_e_6877d3da5ad88331a4a02bd682d2718f