### PR TITLE
Fix header_size calculation

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -121,8 +121,10 @@ class Writer:
         static_banner = "\n".join(lines) + "\n"
 
         static_bytes = static_banner.encode()
-        size_line_placeholder = b":header_size=00000\n"
-        header_size = len(static_bytes) + len(size_line_placeholder)
+        size_line = b":header_size=00000\n"
+        header = static_bytes + size_line
+        blank = b"\n"
+        header_size = len(header) + 1
         size_line = f":header_size={header_size:05d}\n".encode()
         banner = static_bytes + size_line
         if os.getenv("PYNYTPROF_DEBUG"):
@@ -131,10 +133,8 @@ class Writer:
             print(f"DEBUG: banner_end={last_line!r}", file=sys.stderr)
 
         self._fh.write(banner)
-        self._offset += len(banner)
-
-        self._fh.write(b"\n")
-        self._offset += 1
+        self._fh.write(blank)
+        self._offset = header_size
 
         self._write_raw_P()
         if os.getenv("PYNYTPROF_DEBUG"):
@@ -298,7 +298,8 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
         static_hdr = "\n".join(lines_hdr) + "\n"
         static_bytes = static_hdr.encode()
         placeholder = b":header_size=00000\n"
-        header_size = len(static_bytes) + len(placeholder)
+        header = static_bytes + placeholder
+        header_size = len(header) + 1
         size_line = f":header_size={header_size:05d}\n".encode()
         banner = static_bytes + size_line
         f.write(banner)

--- a/tests/test_header_size_and_no_placeholder.py
+++ b/tests/test_header_size_and_no_placeholder.py
@@ -33,7 +33,7 @@ def test_header_size_and_no_placeholder(tmp_path):
     declared = int(m.group(1))
 
     # header returned by split() already includes the final '\n'
-    actual = len(header) + 1
+    actual = len(header) + 2   # include the single blank-line LF
     assert declared == actual, (
         f"header_size={declared}, but header length={actual}"
     )

--- a/tests/test_header_size_field.py
+++ b/tests/test_header_size_field.py
@@ -35,6 +35,6 @@ def test_header_size_points_to_P(tmp_path, writer):
     assert m, "header_size line missing"
     declared = int(m.group(1))
     p_offset = len(header) + 2
-    assert declared + 1 == p_offset, (
-        f"header_size {declared} should equal P offset {p_offset} minus 1"
+    assert declared == p_offset, (
+        f"header_size {declared} should equal P offset {p_offset}"
     )


### PR DESCRIPTION
## Summary
- adjust header_size calculation to point after banner blank line
- update header size tests

## Testing
- `pytest -n auto -q`
- `PYNYTPROF_WRITER=py PYTHONPATH=src python -m pynytprof.tracer tests/example_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6877dc1d77b0833181a32ef6f4c3fe47