### PR TITLE
Fix header_size and remove blank banner line

### DIFF
--- a/docs/FILE_FORMAT.md
+++ b/docs/FILE_FORMAT.md
@@ -10,8 +10,8 @@ layered later.
 1  ASCII banner (text header)
 ──────────────────────────────────────────────────────────────────────
 
-Each line ends in a single `\n`. A blank line follows the banner before the
-binary stream begins. Format:
+Each line ends in a single `\n`. The binary stream begins immediately after the
+last banner line. Format:
 
 ```text
 NYTProf <major> <minor>\n

--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -82,6 +82,7 @@ class Writer:
         _debug_write(self._fh, struct.pack("<I", pid))
         _debug_write(self._fh, struct.pack("<I", ppid))
         _debug_write(self._fh, struct.pack("<d", tstamp))
+        self._offset += 17
 
     def _write_header(self) -> None:
         try:
@@ -122,9 +123,7 @@ class Writer:
 
         static_bytes = static_banner.encode()
         size_line = b":header_size=00000\n"
-        header = static_bytes + size_line
-        blank = b"\n"
-        header_size = len(header) + 1
+        header_size = len(static_bytes) + len(size_line)
         size_line = f":header_size={header_size:05d}\n".encode()
         banner = static_bytes + size_line
         if os.getenv("PYNYTPROF_DEBUG"):
@@ -133,7 +132,6 @@ class Writer:
             print(f"DEBUG: banner_end={last_line!r}", file=sys.stderr)
 
         self._fh.write(banner)
-        self._fh.write(blank)
         self._offset = header_size
 
         self._write_raw_P()

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -99,9 +99,8 @@ static unsigned emit_banner(FILE *fp) {
                        "!evals=0\n",
                        NYTPROF_MAJOR, NYTPROF_MINOR, rfc_2822_time(), basetime,
                        PY_VERSION, sizeof(double), platform_name(), sysconf(_SC_CLK_TCK));
-    unsigned hdr_size = strlen(buf) + 19; /* size_line length = 19 */
+    unsigned hdr_size = strlen(buf) + 19; /* include size line */
     fprintf(fp, "%s:header_size=%05u\n", buf, hdr_size);
-    fputc('\n', fp);          /* blank line not counted */
     return hdr_size;
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
+import re
+
+
 def get_chunk_start(data):
-    cutoff = data.index(b"\n\nP") + 2
+    m = re.search(rb":header_size=(\d+)\n", data)
+    assert m, "header_size line missing"
+    cutoff = int(m.group(1))
+    assert data[cutoff:cutoff + 1] == b"P"
     return cutoff
 
 

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -9,7 +10,7 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     tags=[]
     off=idx
     while off < len(data):

--- a/tests/test_banner_ends_and_first_tag_is_P.py
+++ b/tests/test_banner_ends_and_first_tag_is_P.py
@@ -18,5 +18,9 @@ def test_banner_ends_and_first_tag_is_P(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\n\nP')
-    assert data[idx:idx+3] == b"\n\nP"
+    import re
+    m = re.search(rb":header_size=(\d+)\n", data)
+    p_off = int(m.group(1))
+    assert data[p_off - 1] == 0x0A
+    assert data[p_off - 2] != 0x0A
+    assert data[p_off:p_off + 1] == b"P"

--- a/tests/test_banner_exact_termination.py
+++ b/tests/test_banner_exact_termination.py
@@ -16,7 +16,7 @@ def test_banner_ends_with_single_newline(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.find(b"\n\nP")
-    assert idx != -1, "Did not find \\n\nP"
-    next_bytes = data[idx:idx+3]
-    assert next_bytes == b"\n\nP", f"Expected exactly '\\n\nP', got {next_bytes}"
+    import re
+    m = re.search(rb":header_size=(\d+)\n", data)
+    off = int(m.group(1))
+    assert data[off - 1] == 0x0A and data[off - 2] != 0x0A

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 def test_c_writer_emits_C_chunk(tmp_path):
     import subprocess, sys, os
     from pathlib import Path
@@ -9,7 +10,7 @@ def test_c_writer_emits_C_chunk(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\n\nP") + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 def test_c_writer_emits_D_chunk(tmp_path):
     import subprocess, sys, os
     from pathlib import Path
@@ -9,7 +10,7 @@ def test_c_writer_emits_D_chunk(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\n\nP") + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -14,7 +15,7 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         'tests/example_script.py'
     ])
     data = out.read_bytes()
-    cutoff = data.index(b'\n\nP') + 2
+    cutoff = get_chunk_start(data)
     tags = []
     off = cutoff
     while off < len(data):

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 from pathlib import Path, PurePosixPath
 import subprocess, os, sys, struct
 
@@ -13,7 +14,7 @@ def test_py_writer_chunks(tmp_path):
         },
     )
     data = out.read_bytes()
-    end = data.index(b"\n\nP") + 2
+    end = get_chunk_start(data)
     chunks = data[end:]
     tokens = []
     off = 0

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -16,7 +17,7 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     tags = []
     off = idx
     while off < len(data):

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 def test_c_writer_chunk_sequence(tmp_path):
     import subprocess, sys, os
     from pathlib import Path
@@ -9,7 +10,7 @@ def test_c_writer_chunk_sequence(tmp_path):
     }
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
     data = out.read_bytes()
-    cutoff = data.index(b"\n\nP") + 2
+    cutoff = get_chunk_start(data)
     tokens = []
     off = cutoff
     while off < len(data):

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -23,7 +24,7 @@ def test_dchunk_binary(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     idx += 17  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -14,7 +15,7 @@ def test_D_chunk_contains_records(tmp_path):
         env=env,
     )
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     idx += 17
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import subprocess, sys, struct, os, tempfile, pathlib
 
 def test_exactly_one_p_record(tmp_path):
@@ -18,7 +19,7 @@ def test_exactly_one_p_record(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b'P'
     pid_bytes = data[idx+1:idx+5]
     assert pid_bytes == p.pid.to_bytes(4, 'little')

--- a/tests/test_header_blank_lines.py
+++ b/tests/test_header_blank_lines.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 
 def test_exact_two_newlines_before_P(tmp_path):
@@ -22,10 +23,10 @@ def test_exact_two_newlines_before_P(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     count = 0
     i = idx - 1
     while i >= 0 and data[i] == 0x0A:
         count += 1
         i -= 1
-    assert count == 2, f"Expected 2 blank lines before P, found {count}"
+    assert count == 1, f"Expected 1 newline before P, found {count}"

--- a/tests/test_header_newline_and_p_tag.py
+++ b/tests/test_header_newline_and_p_tag.py
@@ -1,5 +1,6 @@
 import os, subprocess, sys
 from pathlib import Path
+from tests.conftest import get_chunk_start
 
 
 def test_exactly_two_lf_before_p(tmp_path):
@@ -10,15 +11,15 @@ def test_exactly_two_lf_before_p(tmp_path):
                           "-o", str(out), "-e", "pass"], env=env)
     p.wait()
     data = out.read_bytes()
-    idx_p = data.index(b'\n\nP') + 2  # start of raw P record
+    idx_p = get_chunk_start(data)  # start of raw P record
     # Count consecutive LF bytes immediately before 'P'
     lf_count = 0
     i = idx_p - 1
     while data[i] == 0x0A:
         lf_count += 1
         i -= 1
-    assert lf_count == 2, (
-        f"expected exactly 2 LF before 'P', found {lf_count}"
+    assert lf_count == 1, (
+        f"expected exactly 1 LF before 'P', found {lf_count}"
     )
     # First 4 payload bytes must be the real PID, not length=16
     pid = int.from_bytes(data[idx_p+1:idx_p+5], 'little')

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -18,4 +18,4 @@ def test_first_token_is_P(tmp_path):
     data = out.read_bytes()
     cutoff = get_chunk_start(data)
     assert data[cutoff] == 0x50  # 'P'
-    assert data[cutoff - 1] == 0x0A  # banner ends with a blank line
+    assert data[cutoff - 1] == 0x0A  # banner ends with single newline

--- a/tests/test_header_placeholder.py
+++ b/tests/test_header_placeholder.py
@@ -1,5 +1,5 @@
 def test_no_size_placeholder(tmp_path):
-    import os, subprocess, sys
+    import os, subprocess, sys, re
     from pathlib import Path
 
     env = {
@@ -9,5 +9,8 @@ def test_no_size_placeholder(tmp_path):
     }
     out = tmp_path / "nytprof.out"
     subprocess.check_call([sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env)
-    header, _ = out.read_bytes().split(b"\n\n", 1)
+    data = out.read_bytes()
+    m = re.search(rb":header_size=(\d+)\n", data)
+    assert m
+    header = data[: int(m.group(1))]
     assert b"{SIZE" not in header

--- a/tests/test_header_size_field.py
+++ b/tests/test_header_size_field.py
@@ -29,12 +29,11 @@ def test_header_size_points_to_P(tmp_path, writer):
         env=env,
     )
     data = out.read_bytes()
-    header, _ = data.split(b"\n\n", 1)
-    header_txt = header.decode()
-    m = re.search(r":header_size=(\d+)", header_txt)
+    m = re.search(rb":header_size=(\d+)\n", data)
     assert m, "header_size line missing"
     declared = int(m.group(1))
-    p_offset = len(header) + 2
+    p_offset = declared
+    assert data[p_offset:p_offset + 1] == b"P"
     assert declared == p_offset, (
         f"header_size {declared} should equal P offset {p_offset}"
     )

--- a/tests/test_no_blank_line_before_p.py
+++ b/tests/test_no_blank_line_before_p.py
@@ -1,0 +1,27 @@
+import subprocess, sys, os, re
+from pathlib import Path
+from tests.conftest import get_chunk_start
+
+def test_no_blank_line_before_P(tmp_path):
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    out = tmp_path / "nytprof.out"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        "-o",
+        str(out),
+        "-e",
+        "pass",
+    ], env=env, check=True)
+    data = out.read_bytes()
+    p_off = get_chunk_start(data)
+    # exactly one LF before 'P'
+    assert data[p_off - 1] == 0x0A and data[p_off - 2] != 0x0A
+    hdr = re.search(rb":header_size=(\d+)\n", data).group(1)
+    assert int(hdr) == p_off
+

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 from pathlib import Path
 import sys
 import os
@@ -11,9 +12,8 @@ def test_no_buffer_chunk_for_p(tmp_path):
     with Writer(str(out)):
         pass
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     pid_bytes = os.getpid().to_bytes(4, "little")
     assert data[idx+1:idx+5] == pid_bytes
-    assert data.count(b"\n\nP") == 1
 

--- a/tests/test_no_extra_newline_before_first_chunk.py
+++ b/tests/test_no_extra_newline_before_first_chunk.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -20,6 +21,6 @@ def test_no_extra_newline_before_first_chunk(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\n\nP')
-    assert data[idx+2:idx+3] == b'P', f"Found {data[idx+2:idx+3]!r} before first chunk"
+    idx = get_chunk_start(data)
+    assert data[idx:idx+1] == b'P', f"Found {data[idx:idx+1]!r} before first chunk"
 

--- a/tests/test_no_newline_bytes_after_header.py
+++ b/tests/test_no_newline_bytes_after_header.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -13,7 +14,7 @@ def test_no_newline_bytes_after_header(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    split = data.index(b'\n\nP') + 2 + 1 + 4 + 4 + 8
+    split = get_chunk_start(data) + 1 + 4 + 4 + 8
     tail = data[split:]
     # Assert no 0x0A anywhere in the binary section
     pos = tail.find(b'\n')

--- a/tests/test_no_newlines_after_chunks.py
+++ b/tests/test_no_newlines_after_chunks.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -17,7 +18,7 @@ def test_no_newlines_after_chunks(tmp_path, monkeypatch):
         'tests/example_script.py',
     ], env=env)
     data = out.read_bytes()
-    off = data.index(b'\n\nP') + 2
+    off = get_chunk_start(data)
     while off < len(data):
         length = int.from_bytes(data[off + 1:off + 5], 'little')
         end = off + 5 + length

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -15,7 +16,7 @@ def test_D_payload_free_of_newlines(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     idx += 17  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -15,7 +16,7 @@ def test_S_payload_free_of_newlines(tmp_path):
         env=env
     )
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     idx += 17  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -22,7 +23,7 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         env=os.environ,
     )
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     tags = []
     off = idx
     while off < len(data):

--- a/tests/test_only_one_lf_before_P.py
+++ b/tests/test_only_one_lf_before_P.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -17,6 +18,6 @@ def test_only_one_lf_before_P(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    i = data.index(b'\n\nP')
-    assert data[i:i+3] == b'\n\nP'
-    assert i == data.index(b'\n\nP')  # ensure no earlier instance
+    i = get_chunk_start(data)
+    assert data[i - 1] == 0x0A
+    assert data[i - 2] != 0x0A

--- a/tests/test_p_chunk_layout.py
+++ b/tests/test_p_chunk_layout.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import struct
 import subprocess
@@ -22,7 +23,7 @@ def test_p_chunk_has_no_length_word(tmp_path):
     ], env=env)
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     pid = int.from_bytes(data[idx + 1 : idx + 5], "little")
     assert pid == p.pid, (
         "Found length word instead of PID — P chunk layout is wrong"

--- a/tests/test_p_chunk_pid.py
+++ b/tests/test_p_chunk_pid.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -16,7 +17,7 @@ def test_p_chunk_pid_matches_process(tmp_path):
     )
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx : idx + 1] == b"P"
     pid_le = int.from_bytes(data[idx + 1 : idx + 5], "little")
     assert pid_le == p.pid, f"P-chunk PID {pid_le} != subprocess pid {p.pid}"

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 from pathlib import Path
 import importlib.util
@@ -20,7 +21,7 @@ def test_p_length_is_16(tmp_path, writer):
     tracer.profile_command("pass", out_path=out)
     monkeypatch.undo()
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     pid = int.from_bytes(data[idx+1:idx+5], "little")
     assert pid == os.getpid()

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 import pytest
@@ -14,7 +15,7 @@ def test_p_record_is_17_bytes(tmp_path):
         [sys.executable, "-m", "pynytprof.tracer", "-o", str(out), "-e", "pass"], env=env
     )
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     assert data[idx + 17 : idx + 18] == b"S"
 

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -20,7 +21,7 @@ def test_p_record_format(tmp_path):
     )
     p.wait()
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     payload = data[idx + 1 : idx + 17]
     pid, ppid, ts = struct.unpack("<IId", payload)

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 import pytest
@@ -19,7 +20,7 @@ def test_p_record_length(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     assert data[idx+17:idx+18] in (b"S", b"C")
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -22,7 +23,7 @@ def test_p_record_raw(tmp_path):
         "pass",
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b"\n\nP") + 2
+    idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     assert data[idx+17:idx+18] == b"S"
 

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os, subprocess, sys
 from pathlib import Path
 
@@ -15,7 +16,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         env=env, stderr=subprocess.PIPE, text=True
     )
     data = out.read_bytes()
-    idx = data.index(b'\n\nP') + 2
+    idx = get_chunk_start(data)
     tags = []
     seen = {}
     off = idx

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import subprocess, sys, os, struct
 from pathlib import Path
 
@@ -18,7 +19,7 @@ def test_schunk(tmp_path, writer):
         env=env,
     )
     data = out.read_bytes()
-    end = data.index(b"\n\nP") + 2
+    end = get_chunk_start(data)
     chunks = data[end:]
     tokens = []
     off = 0

--- a/tests/test_single_lf_before_p.py
+++ b/tests/test_single_lf_before_p.py
@@ -1,3 +1,4 @@
+from tests.conftest import get_chunk_start
 import os
 import subprocess
 import sys
@@ -19,7 +20,7 @@ def test_single_lf_before_p(tmp_path):
         '-e', 'pass',
     ], env=env)
     data = out.read_bytes()
-    idx = data.index(b'\n\nP')
-    assert data[idx:idx+3] == b'\n\nP'
-    assert b'\n\n\nP' not in data
+    idx = get_chunk_start(data)
+    assert data[idx - 1] == 0x0A
+    assert data[idx - 2] != 0x0A
 


### PR DESCRIPTION
## Summary
- drop blank line between banner and first `P` token
- ensure `header_size` equals the first binary byte offset
- adjust Python and C writers for the new layout
- update docs and tests to match
- add regression test for no blank line before `P`

## Testing
- `pytest -n auto -q`
- `PYNYTPROF_WRITER=py PYTHONPATH=src python -m pynytprof.tracer tests/example_script.py`
- `nytprofhtml -f nytprof.out.12124` *(fails: `Profile format error: token -25`)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9a222bc8331a4dc4afcfbf3392c