### PR TITLE
Implement F chunk support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def parse_chunks(data: bytes) -> dict:
     idx = 0
     while idx < len(data):
         tag = data[idx : idx + 1]
-        if tag in b"PDSCE":
+        if tag in b"PDSCEF":
             if tag == b"P":
                 length = 16
                 if idx + 1 + length > len(data):

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -19,5 +19,5 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens[3] == b'C'
+    assert tokens[4] == b'C'
 

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -20,5 +20,5 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens[3] == b'C'
+    assert tokens[4] == b'C'
 

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -19,5 +19,5 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens[2] == b'D'
+    assert tokens[3] == b'D'
 

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -20,5 +20,5 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens[2] == b'D'
+    assert tokens[3] == b'D'
 

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -20,5 +20,5 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
-    assert tokens == [b'P', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'F', b'D', b'C', b'E']
 

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -21,5 +21,5 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     assert tokens[-1] == b'E'
-    assert tokens == [b'P', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'F', b'D', b'C', b'E']
 

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -25,7 +25,7 @@ def test_c_writer_chunks(tmp_path):
             continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length
-    assert tokens == [b'P', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'F', b'D', b'C', b'E']
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
 

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -26,5 +26,5 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length
-    assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Got {tags!r}"
+    assert tags == [b'P', b'S', b'F', b'D', b'C', b'E'], f"Got {tags!r}"
 

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -26,7 +26,7 @@ def test_py_writer_chunks(tmp_path):
             continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length
-    assert tokens == [b"P", b"S", b"D", b"C", b"E"]
+    assert tokens == [b"P", b"S", b"F", b"D", b"C", b"E"]
     assert b"A" not in tokens
     assert data.endswith(b"E\x00\x00\x00\x00")
 

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -28,5 +28,5 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
-    assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Got {tags!r}"
+    assert tags == [b"P", b"S", b"F", b"D", b"C", b"E"], f"Got {tags!r}"
 

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -21,5 +21,5 @@ def test_c_writer_chunk_sequence(tmp_path):
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length
-    assert tokens == [b'P', b'S', b'D', b'C', b'E']
+    assert tokens == [b'P', b'S', b'F', b'D', b'C', b'E']
 

--- a/tests/test_chunk_uniqueness.py
+++ b/tests/test_chunk_uniqueness.py
@@ -29,4 +29,4 @@ def test_chunk_uniqueness(tmp_path):
             continue
         if m := pattern.search(line):
             tags.append(m.group(1))
-    assert tags == ['P', 'S', 'D', 'C', 'E']
+    assert tags == ['P', 'S', 'F', 'D', 'C', 'E']

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -28,6 +28,8 @@ def test_dchunk_binary(tmp_path):
     idx += 17  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
+    length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
+    idx += 5 + length
     assert data[idx : idx + 1] == b'D'
     dlen = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     payload = data[idx + 5 : idx + 5 + dlen]

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -19,6 +19,8 @@ def test_D_chunk_contains_records(tmp_path):
     idx += 17
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
+    length = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5 + length
     assert data[idx:idx+1]==b'D'
     dlen = int.from_bytes(data[idx+1:idx+5],'little')
     assert dlen > 1, f"D chunk too small ({dlen}); no records collected"

--- a/tests/test_f_chunk_present.py
+++ b/tests/test_f_chunk_present.py
@@ -1,0 +1,24 @@
+import os, subprocess, sys, struct
+from pathlib import Path
+from tests.conftest import parse_chunks
+
+def test_f_chunk_present(tmp_path):
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    out = tmp_path / "nytprof.out"
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pynytprof.tracer",
+        "-o",
+        str(out),
+        "-e",
+        "pass",
+    ], env=env)
+    data = out.read_bytes()
+    chunks = parse_chunks(data)
+    assert "F" in chunks, "Missing F chunk (file-handle definitions)"
+    assert chunks["F"]["length"] >= 8

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -27,7 +27,7 @@ def test_full_sequence_py(tmp_path, monkeypatch):
     monkeypatch.setenv('PYNTP_FORCE_PY', '1')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), SCRIPT])
-    assert _tokens(out) == b'PSDCE'
+    assert _tokens(out) == b'PSFDCE'
 
 
 def test_full_sequence_c(tmp_path, monkeypatch):
@@ -35,5 +35,5 @@ def test_full_sequence_c(tmp_path, monkeypatch):
     monkeypatch.setenv('PYNYTPROF_WRITER', 'py')
     monkeypatch.setenv('PYTHONPATH', str(Path(__file__).resolve().parents[1] / 'src'))
     subprocess.check_call([sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), SCRIPT])
-    assert _tokens(out) == b'PSDCE'
+    assert _tokens(out) == b'PSFDCE'
 

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -21,6 +21,8 @@ def test_D_payload_free_of_newlines(tmp_path):
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen
+    flen = int.from_bytes(data[idx+1:idx+5],'little')
+    idx += 5 + flen
     # expect D
     assert data[idx:idx+1]==b'D'
     dlen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -35,5 +35,5 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length
 
-    assert tags == [b"P", b"S", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"
+    assert tags == [b"P", b"S", b"F", b"D", b"C", b"E"], f"Found spurious tags: {tags!r}"
 

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -30,7 +30,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         seen[tag] = seen.get(tag, 0) + 1
         off += 5 + length
-    assert tags == [b'P', b'S', b'D', b'C', b'E'], f"Tags: {tags!r}"
+    assert tags == [b'P', b'S', b'F', b'D', b'C', b'E'], f"Tags: {tags!r}"
     assert seen[b'P'] == 1 and seen[b'S'] == 1 and seen[b'D'] == 1 and seen[b'C'] == 1 and seen[b'E'] == 1
     assert all(seen[t] == 1 for t in tags)
     assert all(l > 0 for t, l in seen.items() if t != b'E')

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -34,7 +34,7 @@ def test_schunk(tmp_path, writer):
         if tok == b"S":
             s_off = off
         off += 5 + length
-    assert tokens == [b"P", b"S", b"D", b"C", b"E"]
+    assert tokens == [b"P", b"S", b"F", b"D", b"C", b"E"]
     assert s_off is not None
     slen = int.from_bytes(chunks[s_off + 1 : s_off + 5], "little")
     assert slen % 28 == 0 and slen > 0

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -22,5 +22,5 @@ def test_one_F_chunk(tmp_path, monkeypatch):
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length
     f_positions = [i for i, t in enumerate(tags) if t == b'F']
-    assert f_positions == [], f'Unexpected F chunk positions: {f_positions}'
+    assert f_positions == [2], f'Unexpected F chunk positions: {f_positions}'
 


### PR DESCRIPTION
## Summary
- add missing F chunk support in `_pywrite` and C writer
- register source file paths when writing profiles
- adapt parse helper and tests for new F chunk
- ensure new `F` chunk presence

## Testing
- `pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a6dfec808331bb619b33288d7b20