### PR TITLE
Write raw 'E' record (no length); add regression test

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -289,10 +289,14 @@ class Writer:
             self._write_chunk(b"F", f_payload)
             self._offset += 5 + len(f_payload)
 
-        for tag in [b"D", b"C", b"E"]:
-            payload = bytes(self._payloads.get(tag, b"")) if tag != b"E" else b""
+        for tag in [b"D", b"C"]:
+            payload = bytes(self._payloads.get(tag, b""))
             self._write_chunk(tag, payload)
             self._offset += 5 + len(payload)
+
+        # final end marker is a raw byte with no length
+        _debug_write(self._fh, b"E")
+        self._offset += 1
         self._fh.close()
         self._fh = None
 

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -94,14 +94,18 @@ def read(path: str) -> dict:
             offset += length
             first = False
         else:
-            if offset + 4 > len(data):
-                raise ValueError("truncated length")
-            length = struct.unpack_from("<I", data, offset)[0]
-            offset += 4
-            if offset + length > len(data):
-                raise ValueError("truncated payload")
-            payload = data[offset : offset + length]
-            offset += length
+            if tok == "E":
+                length = 0
+                payload = b""
+            else:
+                if offset + 4 > len(data):
+                    raise ValueError("truncated length")
+                length = struct.unpack_from("<I", data, offset)[0]
+                offset += 4
+                if offset + length > len(data):
+                    raise ValueError("truncated payload")
+                payload = data[offset : offset + length]
+                offset += length
 
         if tok == "A":
             if not payload or payload[-1] != 0:

--- a/src/pynytprof/verify.py
+++ b/src/pynytprof/verify.py
@@ -73,6 +73,9 @@ def verify(path: str, quiet: bool = False) -> bool:
                             raise ValueError("truncated payload")
                         payload = peek + rest
                     first = False
+                elif tag == b"E":
+                    length = 0
+                    payload = b""
                 else:
                     length_b = f.read(4)
                     if len(length_b) != 4:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,12 @@ def parse_chunks(data: bytes) -> dict:
                 }
                 idx += 17
                 continue
+            if tag == b"E":
+                off = idx
+                chunks[tag.decode()] = {"offset": off, "length": 0, "payload": b""}
+                idx += 1
+                continue
+
             length = int.from_bytes(data[idx + 1 : idx + 5], "little")
             if idx + 5 + length > len(data):
                 idx += 1

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -27,5 +27,5 @@ def test_c_writer_chunks(tmp_path):
         off += 5 + length
     assert tokens == [b'P', b'S', b'F', b'D', b'C', b'E']
     assert b"A" not in tokens
-    assert data.endswith(b"E\x00\x00\x00\x00")
+    assert data.endswith(b"E")
 

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -28,5 +28,5 @@ def test_py_writer_chunks(tmp_path):
         off += 5 + length
     assert tokens == [b"P", b"S", b"F", b"D", b"C", b"E"]
     assert b"A" not in tokens
-    assert data.endswith(b"E\x00\x00\x00\x00")
+    assert data.endswith(b"E")
 

--- a/tests/test_chunk_uniqueness.py
+++ b/tests/test_chunk_uniqueness.py
@@ -23,10 +23,13 @@ def test_chunk_uniqueness(tmp_path):
     )
     pattern = re.compile(r"^DEBUG: write tag=(\w) len=(\d+)")
     tags = []
-    for line in proc.stderr.splitlines():
+    lines = proc.stderr.splitlines()
+    for line in lines:
         if line.startswith("DEBUG: wrote raw P record"):
             tags.append('P')
             continue
         if m := pattern.search(line):
             tags.append(m.group(1))
+    if lines and lines[-1].startswith("DEBUG: about to write raw data") and lines[-1].endswith("=1"):
+        tags.append('E')
     assert tags == ['P', 'S', 'F', 'D', 'C', 'E']

--- a/tests/test_writer_end_record.py
+++ b/tests/test_writer_end_record.py
@@ -1,0 +1,22 @@
+import io
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pynytprof._pywrite import Writer
+
+
+class NonClosingBytesIO(io.BytesIO):
+    def close(self):
+        pass
+
+
+def test_e_record_has_no_length():
+    buf = NonClosingBytesIO()
+    w = Writer(fp=buf)
+    w.close()
+    data = buf.getvalue()
+    idx = data.rfind(b'E')
+    assert len(data) - idx == 1, (
+        'End record must be raw single byte; found extra bytes'
+    )


### PR DESCRIPTION
## Summary
- add regression test ensuring 'E' record is only one byte
- emit final 'E' as raw byte in `_pywrite.Writer.close`
- teach helpers and tests to handle lengthless 'E'
- update reader and verify utilities

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687a4428e07883318523777fe5cc809d