### PR TITLE
Add Perl interoperability test and uniform P framing

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -105,8 +105,9 @@ class Writer:
             + struct.pack("<d", tstamp)
         )
         _debug_write(self._fh, b"P")
+        _debug_write(self._fh, len(payload).to_bytes(4, "little"))
         _debug_write(self._fh, payload)
-        self._offset += 1 + len(payload)
+        self._offset += 5 + len(payload)
 
     def _write_F_chunk(self) -> None:
         if self._fh is None:
@@ -168,7 +169,7 @@ class Writer:
 
         self._write_raw_P()
         if os.getenv("PYNYTPROF_DEBUG"):
-            print("DEBUG: wrote raw P record (17 B)", file=sys.stderr)
+            print("DEBUG: wrote raw P record (21 B)", file=sys.stderr)
 
     def _write_chunk(self, tag: bytes, payload: bytes) -> None:
         payload = payload.replace(b"\n", b"\x01")

--- a/src/pynytprof/_writer.c
+++ b/src/pynytprof/_writer.c
@@ -131,11 +131,12 @@ static void emit_header(FILE *fp) {
     clock_gettime(CLOCK_REALTIME, &ts);
     double t = (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
     fputc('P', fp);
+    store_le32(fp, 16);
     store_le32(fp, (uint32_t)getpid());
     store_le32(fp, (uint32_t)getppid());
     store_le_double(fp, t);
     if (getenv("PYNYTPROF_DEBUG")) {
-        fprintf(stderr, "DEBUG: wrote raw P record (17 B)\n");
+        fprintf(stderr, "DEBUG: wrote raw P record (21 B)\n");
     }
 
 }

--- a/src/pynytprof/reader.py
+++ b/src/pynytprof/reader.py
@@ -87,9 +87,12 @@ def read(path: str) -> dict:
         tok = tok.decode()
         offset += 1
         if first and tok == "P":
-            if offset + 16 > len(data):
-                raise ValueError("truncated P chunk")
-            length = 16
+            if offset + 4 > len(data):
+                raise ValueError("truncated length")
+            length = struct.unpack_from("<I", data, offset)[0]
+            offset += 4
+            if offset + length > len(data):
+                raise ValueError("truncated payload")
             payload = data[offset : offset + length]
             offset += length
             first = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,16 +17,17 @@ def parse_chunks(data: bytes) -> dict:
         tag = data[idx : idx + 1]
         if tag in b"PDSCEF":
             if tag == b"P":
-                if idx + 17 > len(data):
+                if idx + 21 > len(data):
                     break
-                payload = data[idx + 1 : idx + 17]
+                length = int.from_bytes(data[idx + 1 : idx + 5], "little")
+                payload = data[idx + 5 : idx + 5 + length]
                 off = idx
                 chunks[tag.decode()] = {
                     "offset": off,
-                    "length": 16,
+                    "length": length,
                     "payload": payload,
                 }
-                idx += 17
+                idx += 5 + length
                 continue
             if tag == b"E":
                 off = idx

--- a/tests/test_S_and_D_non_empty.py
+++ b/tests/test_S_and_D_non_empty.py
@@ -19,7 +19,7 @@ def test_S_and_D_non_empty(tmp_path, monkeypatch):
     while off < len(data):
         tag = data[off:off+1]
         if tag == b"P":
-            off += 17
+            off += 21
             seen[tag] = 16
             continue
         length = int.from_bytes(data[off+1:off+5], "little")

--- a/tests/test_active_py_s_and_d_present.py
+++ b/tests/test_active_py_s_and_d_present.py
@@ -17,7 +17,7 @@ def test_active_writer_includes_S_and_D(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_callgraph_pyonly.py
+++ b/tests/test_callgraph_pyonly.py
@@ -21,7 +21,7 @@ def test_callgraph_py(tmp_path):
     )
     data = out.read_bytes()
     start = get_chunk_start(data)
-    off = start + 17
+    off = start + 21
     d_pos = data.index(b"D", off)
     d_len = struct.unpack_from("<I", data, d_pos + 1)[0]
     assert d_len >= 1

--- a/tests/test_chunk_C_c.py
+++ b/tests/test_chunk_C_c.py
@@ -17,7 +17,7 @@ def test_c_writer_emits_C_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_C_fourth_c.py
+++ b/tests/test_chunk_C_fourth_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_C_fourth_py.py
+++ b/tests/test_chunk_C_fourth_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_C_fourth(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_c.py
+++ b/tests/test_chunk_D_c.py
@@ -17,7 +17,7 @@ def test_c_writer_emits_D_chunk(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_D_third_c.py
+++ b/tests/test_chunk_D_third_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_D_third_py.py
+++ b/tests/test_chunk_D_third_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_D_third(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_c.py
+++ b/tests/test_chunk_E_last_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_E_last_py.py
+++ b/tests/test_chunk_E_last_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_E_last(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_c.py
+++ b/tests/test_chunk_S_second_c.py
@@ -15,7 +15,7 @@ def test_c_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_S_second_py.py
+++ b/tests/test_chunk_S_second_py.py
@@ -16,7 +16,7 @@ def test_py_writer_emits_S_second(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_c.py
+++ b/tests/test_chunk_c.py
@@ -21,7 +21,7 @@ def test_c_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(chunks[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_chunk_count_py.py
+++ b/tests/test_chunk_count_py.py
@@ -22,7 +22,7 @@ def test_only_five_top_level_chunks(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5],'little')
         off += 5 + length

--- a/tests/test_chunk_py.py
+++ b/tests/test_chunk_py.py
@@ -22,7 +22,7 @@ def test_py_writer_chunks(tmp_path):
         tok = chunks[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(chunks[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_active_py.py
+++ b/tests/test_chunk_sequence_active_py.py
@@ -24,7 +24,7 @@ def test_active_writer_chunk_sequence(tmp_path, monkeypatch):
         tok = data[off : off + 1]
         tags.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_chunk_sequence_c.py
+++ b/tests/test_chunk_sequence_c.py
@@ -17,7 +17,7 @@ def test_c_writer_chunk_sequence(tmp_path):
         tok = data[off:off+1]
         tokens.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], "little")
         off += 5 + length

--- a/tests/test_dchunk_binary.py
+++ b/tests/test_dchunk_binary.py
@@ -25,7 +25,7 @@ def test_dchunk_binary(tmp_path):
     )
     data = out.read_bytes()
     idx = get_chunk_start(data)
-    idx += 17  # skip P record
+    idx += 21  # skip P record
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')
     idx += 5 + length
     length = int.from_bytes(data[idx + 1 : idx + 5], 'little')

--- a/tests/test_dchunk_has_records.py
+++ b/tests/test_dchunk_has_records.py
@@ -16,7 +16,7 @@ def test_D_chunk_contains_records(tmp_path):
     )
     data = out.read_bytes()
     idx = get_chunk_start(data)
-    idx += 17
+    idx += 21
     length = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + length
     length = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_debug_chunk_summary.py
+++ b/tests/test_debug_chunk_summary.py
@@ -15,5 +15,5 @@ def test_debug_chunk_summary(tmp_path):
         [sys.executable, '-m', 'pynytprof.tracer', '-o', str(out), 'tests/example_script.py'],
         env=env, stderr=subprocess.PIPE, text=True
     )
-    assert 'DEBUG: wrote raw P record (17 B)' in proc.stderr
+    assert 'DEBUG: wrote raw P record (21 B)' in proc.stderr
 

--- a/tests/test_excactly_one_p.py
+++ b/tests/test_excactly_one_p.py
@@ -21,8 +21,8 @@ def test_exactly_one_p_record(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b'P'
-    pid_bytes = data[idx+1:idx+5]
+    pid_bytes = data[idx+5:idx+9]
     assert pid_bytes == p.pid.to_bytes(4, 'little')
-    s_off = data.index(b'S', idx + 17)
-    assert s_off == idx + 17
+    s_off = data.index(b'S', idx + 21)
+    assert s_off == idx + 21
 

--- a/tests/test_full_sequence.py
+++ b/tests/test_full_sequence.py
@@ -14,7 +14,7 @@ def _tokens(out):
         tok = data[off:off+1]
         toks.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_header_newline_and_p_tag.py
+++ b/tests/test_header_newline_and_p_tag.py
@@ -21,5 +21,5 @@ def test_exactly_two_lf_before_p(tmp_path):
     assert lf_count == 1, (
         f"expected exactly 1 LF before 'P', found {lf_count}"
     )
-    pid = int.from_bytes(data[idx_p+1:idx_p+5], 'little')
+    pid = int.from_bytes(data[idx_p+5:idx_p+9], 'little')
     assert pid == p.pid, "PID not at expected offset"

--- a/tests/test_no_buffer_chunk_for_p.py
+++ b/tests/test_no_buffer_chunk_for_p.py
@@ -15,5 +15,6 @@ def test_no_buffer_chunk_for_p(tmp_path):
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
     pid_bytes = os.getpid().to_bytes(4, "little")
-    assert data[idx+1:idx+5] == pid_bytes
+    assert data[idx+1:idx+5] == (16).to_bytes(4, "little")
+    assert data[idx+5:idx+9] == pid_bytes
 

--- a/tests/test_no_newlines_in_dpayload.py
+++ b/tests/test_no_newlines_in_dpayload.py
@@ -17,7 +17,7 @@ def test_D_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = get_chunk_start(data)
-    idx += 17  # skip P
+    idx += 21  # skip P
     # skip S
     slen = int.from_bytes(data[idx+1:idx+5],'little')
     idx += 5 + slen

--- a/tests/test_no_newlines_in_spayload.py
+++ b/tests/test_no_newlines_in_spayload.py
@@ -17,7 +17,7 @@ def test_S_payload_free_of_newlines(tmp_path):
     )
     data = out.read_bytes()
     idx = get_chunk_start(data)
-    idx += 17  # skip P
+    idx += 21  # skip P
     # expect S tag
     assert data[idx:idx+1]==b'S'
     slen = int.from_bytes(data[idx+1:idx+5],'little')

--- a/tests/test_no_spurious_tags_py.py
+++ b/tests/test_no_spurious_tags_py.py
@@ -30,7 +30,7 @@ def test_no_spurious_tags(tmp_path, monkeypatch):
         tag = data[off : off + 1]
         tags.append(tag)
         if tag == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off + 1 : off + 5], "little")
         off += 5 + length

--- a/tests/test_p_chunk_has_length_word.py
+++ b/tests/test_p_chunk_has_length_word.py
@@ -13,7 +13,7 @@ def test_p_chunk_payload_length(tmp_path):
     p.wait()
     data = out.read_bytes()
     idx = get_chunk_start(data)
-    payload = data[idx + 1 : idx + 17]
+    payload = data[idx + 5 : idx + 21]
     assert len(payload) == 16
     pid = struct.unpack_from('<I', payload)[0]
     assert pid == p.pid

--- a/tests/test_p_chunk_layout.py
+++ b/tests/test_p_chunk_layout.py
@@ -24,7 +24,7 @@ def test_p_chunk_no_length_word(tmp_path):
     p.wait()
     data = out.read_bytes()
     p_off = data.index(b"\nP") + 1
-    pid = struct.unpack_from('<I', data, p_off + 1)[0]
+    pid = struct.unpack_from('<I', data, p_off + 5)[0]
     assert pid == p.pid, f"pid mismatch (found {pid}, expected {p.pid})"
-    next_tag = data[p_off + 17 : p_off + 18]
+    next_tag = data[p_off + 21 : p_off + 22]
     assert next_tag in b'SFDCE', f"unexpected next tag {next_tag!r}"

--- a/tests/test_p_chunk_pid.py
+++ b/tests/test_p_chunk_pid.py
@@ -19,5 +19,5 @@ def test_p_chunk_pid_matches_process(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx : idx + 1] == b"P"
-    pid_le = int.from_bytes(data[idx + 1 : idx + 5], "little")
+    pid_le = int.from_bytes(data[idx + 5 : idx + 9], "little")
     assert pid_le == p.pid, f"P-chunk PID {pid_le} != subprocess pid {p.pid}"

--- a/tests/test_p_chunk_size.py
+++ b/tests/test_p_chunk_size.py
@@ -1,13 +1,13 @@
 import io, struct
 from pynytprof._pywrite import Writer
 
-def test_p_record_is_17_bytes():
+def test_p_record_is_21_bytes():
     buf = io.BytesIO()
     w = Writer(fp=buf)
     w._write_raw_P()
     data = buf.getvalue()
     assert data[:1] == b'P'
-    assert len(data) == 17, (
-        f'P record should be 17 bytes (tag+payload), got {len(data)}'
+    assert len(data) == 21, (
+        f'P record should be 21 bytes (tag+payload), got {len(data)}'
     )
 

--- a/tests/test_p_length_is_16.py
+++ b/tests/test_p_length_is_16.py
@@ -23,7 +23,7 @@ def test_p_payload_is_16_bytes(tmp_path, writer):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
-    payload = data[idx+1:idx+17]
+    payload = data[idx+5:idx+21]
     pid2, ppid, ts = struct.unpack("<IId", payload)
     assert len(payload) == 16
     assert pid2 == os.getpid()

--- a/tests/test_p_record_17_bytes.py
+++ b/tests/test_p_record_17_bytes.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 
-def test_p_record_is_17_bytes(tmp_path):
+def test_p_record_is_21_bytes(tmp_path):
     out = tmp_path / "nytprof.out"
     env = {
         **os.environ,
@@ -17,5 +17,5 @@ def test_p_record_is_17_bytes(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
-    assert data[idx + 17 : idx + 18] == b"S"
+    assert data[idx + 21 : idx + 22] == b"S"
 

--- a/tests/test_p_record_format.py
+++ b/tests/test_p_record_format.py
@@ -23,7 +23,7 @@ def test_p_record_format(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
-    payload = data[idx + 1 : idx + 17]
+    payload = data[idx + 5 : idx + 21]
     pid, ppid, ts = struct.unpack("<IId", payload)
     assert pid == p.pid
     assert ppid == os.getpid()

--- a/tests/test_p_record_length.py
+++ b/tests/test_p_record_length.py
@@ -22,6 +22,6 @@ def test_p_record_length(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
-    assert data[idx+17:idx+18] in (b"S", b"C")
+    assert data[idx+21:idx+22] in (b"S", b"C")
 
 

--- a/tests/test_p_record_raw.py
+++ b/tests/test_p_record_raw.py
@@ -25,5 +25,5 @@ def test_p_record_raw(tmp_path):
     data = out.read_bytes()
     idx = get_chunk_start(data)
     assert data[idx:idx+1] == b"P"
-    assert data[idx+17:idx+18] == b"S"
+    assert data[idx+21:idx+22] == b"S"
 

--- a/tests/test_perl_parse_default_profile.py
+++ b/tests/test_perl_parse_default_profile.py
@@ -1,0 +1,33 @@
+import os, subprocess, sys, shutil
+from pathlib import Path
+import pytest
+
+
+def test_perl_parses_default_profile(tmp_path):
+    if not shutil.which("perl"):
+        pytest.skip("perl missing")
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    script = Path(__file__).resolve().parents[1] / "tests" / "example_script.py"
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", str(script)],
+        cwd=tmp_path,
+        env=env,
+    )
+    out_files = list(Path(tmp_path).glob("nytprof.out.*"))
+    assert len(out_files) == 1
+    prof = out_files[0]
+    proc = subprocess.run(
+        [
+            "perl",
+            "-MDevel::NYTProf::Data",
+            "-e",
+            "Devel::NYTProf::Data->new({ filename => shift, quiet => 1 })",
+            str(prof),
+        ],
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout

--- a/tests/test_pywrite_full_sequence.py
+++ b/tests/test_pywrite_full_sequence.py
@@ -24,7 +24,7 @@ def test_pywrite_exact_sequence(tmp_path, monkeypatch):
         tag = data[off:off+1]
         tags.append(tag)
         if tag == b'P':
-            off += 17
+            off += 21
             seen[tag] = seen.get(tag, 0) + 1
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')

--- a/tests/test_s_offset_after_p.py
+++ b/tests/test_s_offset_after_p.py
@@ -26,5 +26,5 @@ def test_s_offset_after_p(tmp_path):
     assert 'P' in chunks and 'S' in chunks
     p_chunk = chunks['P']
     s_chunk = chunks['S']
-    expected = p_chunk['offset'] + 1 + p_chunk['length']
+    expected = p_chunk['offset'] + 5 + p_chunk['length']
     assert s_chunk['offset'] == expected

--- a/tests/test_s_offset_matches_p_length.py
+++ b/tests/test_s_offset_matches_p_length.py
@@ -23,5 +23,5 @@ def test_s_offset_matches_p_chunk_length(tmp_path):
     p_off = chunks['P']['offset']
     p_len = chunks['P']['length']
     s_off = chunks['S']['offset']
-    expected = p_off + 1 + p_len
+    expected = p_off + 5 + p_len
     assert s_off == expected, f"S offset {s_off:#x} != expected {expected:#x}"

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -28,7 +28,7 @@ def test_schunk(tmp_path, writer):
         tok = chunks[off : off + 1]
         tokens.append(tok)
         if tok == b"P":
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(chunks[off + 1 : off + 5], "little")
         if tok == b"S":

--- a/tests/test_single_F_chunk_py.py
+++ b/tests/test_single_F_chunk_py.py
@@ -17,7 +17,7 @@ def test_one_F_chunk(tmp_path, monkeypatch):
         tok = data[off:off+1]
         tags.append(tok)
         if tok == b'P':
-            off += 17
+            off += 21
             continue
         length = int.from_bytes(data[off+1:off+5], 'little')
         off += 5 + length

--- a/tests/test_writer_p_chunk.py
+++ b/tests/test_writer_p_chunk.py
@@ -6,11 +6,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from pynytprof._pywrite import Writer
 
 
-def test_p_chunk_is_17_bytes_writer():
+def test_p_chunk_is_21_bytes_writer():
     buf = io.BytesIO()
     w = Writer(fp=buf)
     w._write_raw_P()
     data = buf.getvalue()
     assert data[0:1] == b'P'
-    assert len(data) == 17
+    assert len(data) == 21
 


### PR DESCRIPTION
## Summary
- ensure perl can parse tracer output with NYTProf::Data
- write P record with length word for consistent framing
- adjust reader and test helpers for the new layout
- update tests expecting 21‑byte P record

## Testing
- `pytest -n auto` *(fails: Profile format error from Devel::NYTProf::Data)*

------
https://chatgpt.com/codex/tasks/task_e_687df91e477083318b371a6221da0253