### PR TITLE
Fix banner newline handling

### DIFF
--- a/src/pynytprof/_pywrite.py
+++ b/src/pynytprof/_pywrite.py
@@ -22,10 +22,8 @@ NYTPROF_MINOR = int(_minor_match.group(1)) if _minor_match else 0
 
 
 def _make_ascii_header(static: str) -> bytes:
-    """Return the finalized banner bytes."""
-    banner = static
-    if not banner.endswith("\n"):
-        banner += "\n"
+    """Return the finalized banner bytes with exactly one trailing LF."""
+    banner = static.rstrip("\n") + "\n"
     return banner.encode()
 
 
@@ -155,7 +153,7 @@ class Writer:
             b"!evals=0",
         ]
 
-        banner = b"\n".join(lines) + b"\n"
+        banner = b"\n".join(lines).rstrip(b"\n") + b"\n"
         if os.getenv("PYNYTPROF_DEBUG"):
             last_line = banner.rstrip(b"\n").split(b"\n")[-1] + b"\n"
             print(f"DEBUG: writing banner len={len(banner)}", file=sys.stderr)
@@ -331,7 +329,7 @@ def write(out_path: str, files, defs, calls, lines, start_ns: int, ticks_per_sec
             b"!evals=0",
         ]
 
-        banner = b"\n".join(lines_hdr) + b"\n"
+        banner = b"\n".join(lines_hdr).rstrip(b"\n") + b"\n"
 
         f.write(banner)
 

--- a/src/pynytprof/_writer.py
+++ b/src/pynytprof/_writer.py
@@ -115,7 +115,7 @@ class Writer:
             f":osname={platform.system().lower()}",
             f":hz={hz}",
         ]
-        static_hdr = "\n".join(hdr_lines) + "\n"
+        static_hdr = "\n".join(hdr_lines).rstrip("\n") + "\n"
         hdr = _make_ascii_header(static_hdr)
         data = hdr
         if os.getenv("PYNYTPROF_DEBUG"):

--- a/src/pynytprof/writer.py
+++ b/src/pynytprof/writer.py
@@ -298,7 +298,7 @@ class Writer:
             f":osname={platform.system().lower()}",
             f":hz={hz}",
         ]
-        banner = "\n".join(lines) + "\n"
+        banner = "\n".join(lines).rstrip("\n") + "\n"
         assert "\0" not in banner
         data = banner.encode()
         if os.getenv("PYNYTPROF_DEBUG"):

--- a/tests/test_banner_termination_integration.py
+++ b/tests/test_banner_termination_integration.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_one_lf_before_p_in_real_run(tmp_path):
+    env = {
+        **os.environ,
+        'PYNYTPROF_WRITER': 'py',
+        'PYTHONPATH': str(Path(__file__).resolve().parents[1] / 'src'),
+    }
+    script = Path(__file__).resolve().parents[1] / 'tests' / 'example_script.py'
+    subprocess.check_call([
+        sys.executable,
+        '-m', 'pynytprof.tracer',
+        str(script),
+    ], cwd=tmp_path, env=env)
+    out = next(Path(tmp_path).glob('nytprof.out.*'))
+    data = out.read_bytes()
+    p_off = data.index(b'\nP') + 1
+    assert data[p_off-1] == 0x0A and data[p_off-2] != 0x0A, "exactly one LF before 'P'"


### PR DESCRIPTION
## Summary
- guarantee single LF at end of ASCII header
- reuse guard when writing banner bytes
- add integration test for banner termination

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6880f723189483319e81b935bc08556d