### PR TITLE
Add failing alignment test

### DIFF
--- a/tests/test_alignment_after_p.py
+++ b/tests/test_alignment_after_p.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.utils import newest_profile_file, parse_nv_size_from_banner
+
+
+def test_alignment_after_p(tmp_path):
+    env = {
+        **os.environ,
+        "PYNYTPROF_WRITER": "py",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+    }
+    script = Path(__file__).with_name("example_script.py")
+    subprocess.check_call(
+        [sys.executable, "-m", "pynytprof.tracer", str(script)],
+        cwd=tmp_path,
+        env=env,
+    )
+    out = newest_profile_file(tmp_path)
+    data = out.read_bytes()
+    p_off = data.index(b"\nP") + 1
+    nv_size = parse_nv_size_from_banner(data)
+    stream_off = p_off + 1 + 4 + 4 + nv_size
+    print("stream_off", stream_off)
+    assert data[stream_off] not in {ord("S"), ord("F"), ord("D"), ord("C"), ord("E")}
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def newest_profile_file(path: str | Path = '.') -> Path:
+    base = Path(path)
+    files = sorted(base.glob('nytprof.out.*'), key=lambda p: p.stat().st_mtime, reverse=True)
+    assert files, 'no nytprof.out.* found'
+    return files[0]
+
+
+def parse_nv_size_from_banner(data: bytes) -> int:
+    banner = data.split(b'\nP', 1)[0]
+    m = re.search(rb':nv_size=(\d+)', banner)
+    return int(m.group(1)) if m else 8


### PR DESCRIPTION
## Summary
- create `newest_profile_file` and `parse_nv_size_from_banner` helpers
- add `test_alignment_after_p` reproducing token misalignment after the `P` record

## Testing
- `pytest -n auto` *(fails: test_alignment_after_p)*

------
https://chatgpt.com/codex/tasks/task_e_688248de99b88331b2503a9a212771d0