### PR TITLE
Implement NYTProf integer encoding helpers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,8 @@ This document describes how **Pynytprof** works and how its modules fit together
 | `convert.py`                  | Convert NYTProf files to other formats                       |
 | `tracer.py`                   | Python tracer collecting per-line execution stats           |
 | `_writer.py`                  | Abstraction for chunked NYTProf output (`py` and `c` modes)  |
-| `_cwrite.*.so`                | Optimized C extension for chunk writing                      |
+| `_cwrite.*.so`                | Optimized C extension for chunk writing               |
+| `protocol.py`                 | Low-level helpers for integer encoding                |
 | `reader.py`                   | Developer helper to decode NYTProf binary files             |
 | `verify.py`                   | Stream verifier for NYTProf files                            |
 | `tests/`                      | Unit and integration tests validating output correctness     |

--- a/src/pynytprof/protocol.py
+++ b/src/pynytprof/protocol.py
@@ -1,0 +1,98 @@
+"""Low-level NYTProf integer encoding helpers."""
+
+from __future__ import annotations
+
+NYTP_TAG_NO_TAG = 256  # sentinel meaning no tag byte should be written
+
+__all__ = [
+    "NYTP_TAG_NO_TAG",
+    "write_tag_u32",
+    "write_tag_i32",
+    "write_u32",
+    "write_i32",
+    "read_u32",
+    "read_i32",
+    "is_valid_varint_prefix",
+]
+
+
+def write_tag_u32(tag: int, val: int) -> bytes:
+    """Return the NYTProf varint encoding of ``val`` optionally prefixed by ``tag``."""
+    out = bytearray()
+    if tag != NYTP_TAG_NO_TAG:
+        out.append(tag & 0xFF)
+
+    i = val & 0xFFFFFFFF
+    if i < 0x80:
+        out.append(i)
+    elif i < 0x4000:
+        out.append((i >> 8) | 0x80)
+        out.append(i & 0xFF)
+    elif i < 0x200000:
+        out.append((i >> 16) | 0xC0)
+        out.append((i >> 8) & 0xFF)
+        out.append(i & 0xFF)
+    elif i < 0x10000000:
+        out.append((i >> 24) | 0xE0)
+        out.append((i >> 16) & 0xFF)
+        out.append((i >> 8) & 0xFF)
+        out.append(i & 0xFF)
+    else:
+        out.append(0xFF)
+        out.append((i >> 24) & 0xFF)
+        out.append((i >> 16) & 0xFF)
+        out.append((i >> 8) & 0xFF)
+        out.append(i & 0xFF)
+
+    return bytes(out)
+
+
+def write_tag_i32(tag: int, val: int) -> bytes:
+    u = val & 0xFFFFFFFF
+    return write_tag_u32(tag, u)
+
+
+def write_u32(val: int) -> bytes:
+    return write_tag_u32(NYTP_TAG_NO_TAG, val)
+
+
+def write_i32(val: int) -> bytes:
+    return write_tag_i32(NYTP_TAG_NO_TAG, val)
+
+
+def read_u32(buf: bytes, off: int) -> tuple[int, int]:
+    d = buf[off]
+    off += 1
+
+    if d < 0x80:
+        newint = d
+    else:
+        if d < 0xC0:
+            newint = d & 0x7F
+            length = 1
+        elif d < 0xE0:
+            newint = d & 0x1F
+            length = 2
+        elif d < 0xFF:
+            newint = d & 0xF
+            length = 3
+        else:
+            newint = 0
+            length = 4
+        for b in buf[off:off + length]:
+            newint = (newint << 8) | b
+        off += length
+
+    return newint, off
+
+
+def read_i32(buf: bytes, off: int) -> tuple[int, int]:
+    u, off = read_u32(buf, off)
+    if u & 0x80000000:
+        u = -((~u + 1) & 0xFFFFFFFF)
+    return u, off
+
+
+def is_valid_varint_prefix(b: int) -> bool:
+    return 0 <= b <= 0xFF
+

--- a/tests/tests_protocol_varints.py
+++ b/tests/tests_protocol_varints.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from pynytprof.protocol import (
+    write_u32,
+    write_i32,
+    write_tag_u32,
+    read_u32,
+    read_i32,
+)
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        0,
+        1,
+        0x7F,
+        0x80 - 1,
+        0x80,
+        0x3FFF,
+        0x4000,
+        0x1FFFFF,
+        0x200000,
+        0x0FFFFFFF,
+        0x10000000,
+        0xFFFFFFFF,
+    ],
+)
+def test_u32_roundtrip(val):
+    encoded = write_u32(val)
+    decoded, off = read_u32(encoded, 0)
+    assert off == len(encoded)
+    assert decoded == val
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        0,
+        -1,
+        1,
+        -0x80,
+        -0x4000,
+        -0x200000,
+        -0x10000000,
+        -0x80000000,
+        0x7FFFFFFF,
+    ],
+)
+def test_i32_roundtrip(val):
+    encoded = write_i32(val)
+    decoded, off = read_i32(encoded, 0)
+    assert off == len(encoded)
+    assert decoded == val
+
+
+def test_tag_prefix_added():
+    val = 0x1234
+    plain = write_u32(val)
+    tagged = write_tag_u32(0x42, val)
+    assert tagged[0] == 0x42
+    assert tagged[1:] == plain
+    assert len(tagged) == len(plain) + 1
+


### PR DESCRIPTION
## Summary
- implement protocol helpers for NYTProf varint encoding
- document the new module in architecture docs
- test round‑trips of u32/i32 varints and tagged values

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68826c3b097483318a5992ef6d1dcba6