### PR TITLE
Replace custom chunk framing with NYTProf token stream

### DIFF
--- a/src/pynytprof/nytp_stream.py
+++ b/src/pynytprof/nytp_stream.py
@@ -1,0 +1,138 @@
+"""Low-level NYTProf binary stream helpers."""
+
+import struct
+
+from .encoding import encode_u32, encode_i32
+
+__all__ = [
+    "TAG_NEW_FID",
+    "TAG_TIME_BLOCK",
+    "TAG_TIME_LINE",
+    "TAG_SUB_ENTRY",
+    "TAG_SUB_RETURN",
+    "TAG_SUB_INFO",
+    "TAG_SUB_CALLERS",
+    "TAG_SRC_LINE",
+    "TAG_DISCOUNT",
+    "TAG_PID_END",
+    "TAG_STRING",
+    "TAG_STRING_UTF8",
+    "write_byte",
+    "write_le32",
+    "write_ledouble",
+    "write_u32_var",
+    "write_i32_var",
+    "write_nv",
+    "write_process_start",
+    "write_process_end",
+    "write_new_fid",
+    "write_time_line",
+    "write_src_line",
+]
+
+# Token values mirror those defined in NYTProf's FileHandle.h
+TAG_NEW_FID = 8
+TAG_TIME_BLOCK = 5
+TAG_TIME_LINE = 6
+TAG_SUB_ENTRY = 17
+TAG_SUB_RETURN = 18
+TAG_SUB_INFO = 10
+TAG_SUB_CALLERS = 11
+TAG_SRC_LINE = 9
+TAG_DISCOUNT = 7
+TAG_PID_END = 13
+TAG_STRING = 14
+TAG_STRING_UTF8 = 15
+TAG_START_DEFLATE = 16
+
+
+def write_byte(b: int) -> bytes:
+    return bytes([b & 0xFF])
+
+
+def write_le32(n: int) -> bytes:
+    return struct.pack("<I", n)
+
+
+def write_ledouble(v: float) -> bytes:
+    return struct.pack("<d", v)
+
+
+def write_u32_var(n: int) -> bytes:
+    return encode_u32(n)
+
+
+def write_i32_var(n: int) -> bytes:
+    return encode_i32(n)
+
+
+def write_nv(v: float) -> bytes:
+    return struct.pack("<d", v)
+
+
+def write_process_start(pid: int, ppid: int, ts: float) -> bytes:
+    return b"P" + write_le32(pid) + write_le32(ppid) + write_ledouble(ts)
+
+
+def write_process_end(pid: int, ts: float) -> bytes:
+    out = bytearray()
+    out += write_byte(TAG_PID_END)
+    out += write_u32_var(pid)
+    out += write_nv(ts)
+    return bytes(out)
+
+
+def write_new_fid(
+    fid: int,
+    eval_fid: int,
+    eval_line: int,
+    flags: int,
+    size: int,
+    mtime: int,
+    name: str | bytes,
+    is_utf8: bool = False,
+) -> bytes:
+    if isinstance(name, str):
+        data = name.encode("utf-8")
+        is_utf8 = True
+    else:
+        data = name
+    out = bytearray()
+    out += write_byte(TAG_NEW_FID)
+    out += write_u32_var(fid)
+    out += write_u32_var(eval_fid)
+    out += write_u32_var(eval_line)
+    out += write_u32_var(flags)
+    out += write_u32_var(size)
+    out += write_u32_var(mtime)
+    length = len(data)
+    out += write_byte(TAG_STRING_UTF8 if is_utf8 else TAG_STRING)
+    out += write_u32_var(length)
+    out += data
+    return bytes(out)
+
+
+def write_time_line(elapsed: int, overflow: int, fid: int, line: int) -> bytes:
+    out = bytearray()
+    out += write_byte(TAG_TIME_LINE)
+    out += write_i32_var(elapsed)
+    out += write_u32_var(fid)
+    out += write_u32_var(line)
+    return bytes(out)
+
+
+def write_src_line(fid: int, line: int, text: str | bytes, is_utf8: bool = False) -> bytes:
+    if isinstance(text, str):
+        data = text.encode("utf-8")
+        is_utf8 = True
+    else:
+        data = text
+    out = bytearray()
+    out += write_byte(TAG_SRC_LINE)
+    out += write_u32_var(fid)
+    out += write_u32_var(line)
+    length = len(data)
+    out += write_byte(TAG_STRING_UTF8 if is_utf8 else TAG_STRING)
+    out += write_u32_var(length)
+    out += data
+    return bytes(out)

--- a/tests/test_stream_roundtrip.py
+++ b/tests/test_stream_roundtrip.py
@@ -1,0 +1,81 @@
+import os
+import subprocess
+from pathlib import Path
+import shutil
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from pynytprof._pywrite import Writer
+
+
+def _perl_available() -> bool:
+    if not shutil.which("perl"):
+        return False
+    try:
+        subprocess.run([
+            "perl",
+            "-MDevel::NYTProf::Data",
+            "-e",
+            "1"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _perl_available(), reason="NYTProf not installed")
+def test_minimal_profile_roundtrip(tmp_path: Path):
+    p = tmp_path / "nytprof.out.test"
+    with p.open("wb") as fh:
+        w = Writer(fh)
+        w.start_profile()
+        w.add_file(
+            fid=1,
+            name="test.pl",
+            size=1,
+            mtime=0,
+            flags=0,
+            eval_fid=0,
+            eval_line=0,
+        )
+        w.add_src_line(fid=1, line=1, text="1;")
+        w.write_time_line(fid=1, line=1, elapsed=-11, overflow=0)
+        w.end_profile()
+
+    subprocess.run(
+        [
+            "perl",
+            "-MDevel::NYTProf::Data",
+            "-e",
+            "Devel::NYTProf::Data->new({filename=>shift,quiet=>1})",
+            str(p),
+        ],
+        check=True,
+    )
+
+
+def test_no_ascii_chunk_bytes(tmp_path: Path):
+    p = tmp_path / "nytprof.out.test"
+    with p.open("wb") as fh:
+        w = Writer(fh)
+        w.start_profile()
+        w.add_file(
+            fid=1,
+            name="x.pl",
+            size=1,
+            mtime=0,
+            flags=0,
+            eval_fid=0,
+            eval_line=0,
+        )
+        w.add_src_line(fid=1, line=1, text="1;")
+        w.write_time_line(fid=1, line=1, elapsed=-11, overflow=0)
+        w.end_profile()
+
+    data = p.read_bytes()
+    hdr_end = data.index(b"\nP")
+    off = hdr_end + 1
+    # P record length is 17 bytes
+    off_after_p = off + 17
+    assert data[off_after_p] not in b"SFDCE"


### PR DESCRIPTION
## Summary
- overhaul `_pywrite.Writer` to emit NYTProf token stream directly
- add `nytp_stream.py` providing low level token helpers
- add round‑trip test using Devel::NYTProf::Data

## Testing
- `pytest -n auto tests/test_stream_roundtrip.py` *(fails: Profile format error reading attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68847eeab4e083318600ddda015b316d